### PR TITLE
Add renameEnabled

### DIFF
--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -81,6 +81,10 @@ public class FileEpisode {
             }
             case DOWNLOADED:
             case RENAMED: {
+                if (!userPrefs.isRenameEnabled()) {
+                    return file.getName();
+                }
+
                 String showName = "";
                 String seasonNum = "";
                 String titleString = "";

--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -23,6 +23,7 @@ public class UserPreferences extends Observable {
     private String seasonPrefix;
     private boolean seasonPrefixLeadingZero;
     private boolean moveEnabled;
+    private boolean renameEnabled;
     private String renameReplacementMask;
     private ProxySettings proxy;
     private boolean checkForUpdates;
@@ -41,6 +42,7 @@ public class UserPreferences extends Observable {
         this.seasonPrefix = Constants.DEFAULT_SEASON_PREFIX;
         this.seasonPrefixLeadingZero = false;
         this.moveEnabled = false;
+        this.renameEnabled = true;
         this.renameReplacementMask = Constants.DEFAULT_REPLACEMENT_MASK;
         this.proxy = new ProxySettings();
         this.checkForUpdates = true;
@@ -164,6 +166,24 @@ public class UserPreferences extends Observable {
      */
     public boolean isMovedEnabled() {
         return this.moveEnabled;
+    }
+
+    public void setRenameEnabled(boolean renameEnabled) {
+        if (hasChanged(this.renameEnabled, renameEnabled)) {
+            this.renameEnabled = renameEnabled;
+
+            setChanged();
+            notifyObservers(new UserPreferencesChangeEvent("renameEnabled", renameEnabled));
+        }
+    }
+
+    /**
+     * Get the status of of rename support
+     *
+     * @return true if selected destination exists, false otherwise
+     */
+    public boolean isRenameEnabled() {
+        return this.renameEnabled;
     }
 
     public void setRecursivelyAddFolders(boolean recursivelyAddFolders) {
@@ -302,8 +322,9 @@ public class UserPreferences extends Observable {
 
     @Override
     public String toString() {
-        return "UserPreferences [destDir=" + destDir + ", seasonPrefix=" + seasonPrefix + ", moveEnabled="
-            + moveEnabled + ", renameReplacementMask=" + renameReplacementMask + ", proxy=" + proxy
+        return "UserPreferences [destDir=" + destDir + ", seasonPrefix=" + seasonPrefix
+            + ", moveEnabled=" + moveEnabled + ", renameEnabled=" + renameEnabled
+            + ", renameReplacementMask=" + renameReplacementMask + ", proxy=" + proxy
             + ", checkForUpdates=" + checkForUpdates + ", setRecursivelyAddFolders=" + recursivelyAddFolders + "]";
     }
 

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -57,6 +57,7 @@ public class PreferencesDialog extends Dialog {
 
     // The controls to save
     private Button moveEnabledCheckbox;
+    private Button renameEnabledCheckbox;
     private Text destDirText;
     private Text seasonPrefixText;
     private Button seasonPrefixLeadingZeroCheckbox;
@@ -134,8 +135,16 @@ public class PreferencesDialog extends Dialog {
         moveEnabledCheckbox = new Button(generalGroup, SWT.CHECK);
         moveEnabledCheckbox.setText("Move Enabled [?]");
         moveEnabledCheckbox.setSelection(prefs.isMovedEnabled());
-        moveEnabledCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, true, 3, 1));
+        moveEnabledCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, true, 2, 1));
         moveEnabledCheckbox.setToolTipText("Whether the 'move to TV location' functionality is enabled");
+
+        renameEnabledCheckbox = new Button(generalGroup, SWT.CHECK);
+        renameEnabledCheckbox.setText("Rename Enabled [?]");
+        renameEnabledCheckbox.setSelection(prefs.isRenameEnabled());
+        renameEnabledCheckbox.setLayoutData(new GridData(GridData.END, GridData.CENTER, true, true, 1, 1));
+        renameEnabledCheckbox.setToolTipText("Whether the 'rename' functionality is enabled.\n"
+                                             + "You can move a file into a folder based on its show\n"
+                                             + "without actually renaming the file");
 
         Label destDirLabel = new Label(generalGroup, SWT.NONE);
         destDirLabel.setText("TV Directory [?]");
@@ -493,6 +502,7 @@ public class PreferencesDialog extends Dialog {
         prefs.setSeasonPrefixLeadingZero(seasonPrefixLeadingZeroCheckbox.getSelection());
         prefs.setRenameReplacementString(replacementStringText.getText());
         prefs.setIgnoreKeywords(Arrays.asList(ignoreWordsText.getText().split("\\s*,\\s*")));
+        prefs.setRenameEnabled(renameEnabledCheckbox.getSelection());
 
         ProxySettings proxySettings = new ProxySettings();
         proxySettings.setEnabled(proxyEnabledCheckbox.getSelection());


### PR DESCRIPTION
Request 1 of #130 

Allow the ability to move files into the proper folders for their show and season, but not renaming the actual file at all.

(Note that this does allow a configuration where NEITHER move nor rename is enabled, which doesn't make a lot of sense.  But it doesn't really cause anything to break, either, and some sort of feature could be added later to pop up a dialog box or something, if the user deselects both options.)