### PR TITLE
Fix removeLast to only remove the matched part of the string.

### DIFF
--- a/src/main/org/tvrenamer/controller/TVRenamer.java
+++ b/src/main/org/tvrenamer/controller/TVRenamer.java
@@ -76,10 +76,11 @@ public class TVRenamer {
 
     }
 
-    private static String removeLast(String input, String match) {
+    public static String removeLast(String input, String match) {
         int idx = input.toLowerCase().lastIndexOf(match);
         if (idx > 0) {
-            input = input.substring(0, idx);
+            input = input.substring(0, idx)
+                + input.substring(idx + match.length(), input.length());
         }
         return input;
     }

--- a/src/test/org/tvrenamer/TVRenamerTest.java
+++ b/src/test/org/tvrenamer/TVRenamerTest.java
@@ -99,6 +99,29 @@ public class TVRenamerTest {
     }
 
     @Test
+    public void testRemoveLast() {
+        // Straighforward removal; note does not remove punctuation/separators
+        assertEquals("foo..baz", TVRenamer.removeLast("foo.bar.baz", "bar"));
+
+        // Implementation detail, but the match is required to be all lower-case,
+        // while the input doesn't
+        assertEquals("Foo..Baz", TVRenamer.removeLast("Foo.Bar.Baz", "bar"));
+
+        // Like the name says, the method only removes the last instance
+        assertEquals("bar.foo..baz", TVRenamer.removeLast("bar.foo.bar.baz", "bar"));
+
+        // Doesn't have to be delimited
+        assertEquals("emassment", TVRenamer.removeLast("embarassment", "bar"));
+
+        // Doesn't necessarily replace anything
+        assertEquals("Foo.Schmar.baz", TVRenamer.removeLast("Foo.Schmar.baz", "bar"));
+
+        // This frankly is probably a bug, but this is currently the expected behavior.
+        // If the match is not all lower-case to begin with, nothing will be matched.
+        assertEquals("Foo.Bar.Baz", TVRenamer.removeLast("Foo.Bar.Baz", "Bar"));
+    }
+
+    @Test
     public void testParseFileName() {
         for (TestInput testInput : values) {
             FileEpisode retval = TVRenamer.parseFilename(testInput.input);


### PR DESCRIPTION
The way removeLast was written, it removed the offending string, plus everything after it.  I don't think that was the intent.  It never broke anything in the test suite until now, though.  I'm adding a separate test just for removeLast.  (Made removeLast public so it's easier to test.)

https://github.com/tvrenamer/tvrenamer/issues/138
