### PR TITLE
Test parsing of filename resolution

### DIFF
--- a/src/main/org/tvrenamer/controller/TVRenamer.java
+++ b/src/main/org/tvrenamer/controller/TVRenamer.java
@@ -76,10 +76,11 @@ public class TVRenamer {
 
     }
 
-    private static String removeLast(String input, String match) {
+    public static String removeLast(String input, String match) {
         int idx = input.toLowerCase().lastIndexOf(match);
         if (idx > 0) {
-            input = input.substring(0, idx);
+            input = input.substring(0, idx)
+                + input.substring(idx + match.length(), input.length());
         }
         return input;
     }

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -46,6 +46,10 @@ public class FileEpisode {
         return episodeNumber;
     }
 
+    public String getEpisodeResolution() {
+        return episodeResolution;
+    }
+
     public File getFile() {
         return file;
     }

--- a/src/test/org/tvrenamer/TVRenamerTest.java
+++ b/src/test/org/tvrenamer/TVRenamerTest.java
@@ -99,6 +99,29 @@ public class TVRenamerTest {
     }
 
     @Test
+    public void testRemoveLast() {
+        // Straighforward removal; note does not remove punctuation/separators
+        assertEquals("foo..baz", TVRenamer.removeLast("foo.bar.baz", "bar"));
+
+        // Implementation detail, but the match is required to be all lower-case,
+        // while the input doesn't
+        assertEquals("Foo..Baz", TVRenamer.removeLast("Foo.Bar.Baz", "bar"));
+
+        // Like the name says, the method only removes the last instance
+        assertEquals("bar.foo..baz", TVRenamer.removeLast("bar.foo.bar.baz", "bar"));
+
+        // Doesn't have to be delimited
+        assertEquals("emassment", TVRenamer.removeLast("embarassment", "bar"));
+
+        // Doesn't necessarily replace anything
+        assertEquals("Foo.Schmar.baz", TVRenamer.removeLast("Foo.Schmar.baz", "bar"));
+
+        // This frankly is probably a bug, but this is currently the expected behavior.
+        // If the match is not all lower-case to begin with, nothing will be matched.
+        assertEquals("Foo.Bar.Baz", TVRenamer.removeLast("Foo.Bar.Baz", "Bar"));
+    }
+
+    @Test
     public void testParseFileName() {
         for (TestInput testInput : values) {
             FileEpisode retval = TVRenamer.parseFilename(testInput.input);

--- a/src/test/org/tvrenamer/TVRenamerTest.java
+++ b/src/test/org/tvrenamer/TVRenamerTest.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
 import org.tvrenamer.controller.ShowInformationListener;
+import org.tvrenamer.controller.TVRenamer;
 import org.tvrenamer.model.Show;
 import org.tvrenamer.model.ShowStore;
 import org.junit.BeforeClass;
@@ -129,6 +130,7 @@ public class TVRenamerTest {
             assertEquals(testInput.input, testInput.show, retval.getShowName());
             assertEquals(testInput.input, Integer.parseInt(testInput.season), retval.getSeasonNumber());
             assertEquals(testInput.input, Integer.parseInt(testInput.episode), retval.getEpisodeNumber());
+            assertEquals(testInput.input, testInput.episodeResolution, retval.getEpisodeResolution());
         }
     }
 


### PR DESCRIPTION
We had added inputs with resolutions (e.g., "720p"), but the test did not actually confirm the resolution was as-expected.  In fact, it would not have passed, due to a bug in removeLast.  This commit is based off of the branch "removelast", which fixes the bug in removeLast, opening up the ability to add this test.