### PR TITLE
Maintain link from FileEpisode to TableItem

### DIFF
--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -1,5 +1,6 @@
 package org.tvrenamer.model;
 
+import org.eclipse.swt.widgets.TableItem;
 import org.tvrenamer.controller.util.StringUtils;
 
 import java.io.File;
@@ -24,6 +25,8 @@ public class FileEpisode {
 
     private UserPreferences userPrefs = UserPreferences.getInstance();
     private EpisodeStatus status;
+
+    private TableItem viewItem = null;
 
     public FileEpisode(String name, int season, int episode, String resolution, File f) {
         showName = name;
@@ -64,6 +67,18 @@ public class FileEpisode {
 
     public void setStatus(EpisodeStatus newStatus) {
         status = newStatus;
+    }
+
+    public TableItem getViewItem() {
+        return viewItem;
+    }
+
+    public boolean setViewItem(TableItem newViewItem) {
+        if ((viewItem != null) && (viewItem != newViewItem)) {
+            logger.finer("changing table item for episode! " + this);
+        }
+        viewItem = newViewItem;
+        return true;
     }
 
     private File getDestinationDirectory() {

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -896,6 +896,7 @@ public class UIStarter {
 
     private static TableItem createTableItem(Table tblResults, String fileName, FileEpisode episode) {
         TableItem item = new TableItem(tblResults, SWT.NONE);
+        episode.setViewItem(item);
         String newFilename = fileName;
         try {
             // Set if the item is checked or not according
@@ -933,7 +934,10 @@ public class UIStarter {
             }
 
             String filename = item.getText(CURRENT_FILE_COLUMN);
-            files.remove(filename);
+            FileEpisode episode = files.remove(filename);
+            if (episode != null) {
+                episode.setViewItem(null);
+            }
 
             resultsTable.remove(index);
             item.dispose();
@@ -943,10 +947,17 @@ public class UIStarter {
 
     private void setSortedItem(int i, int j) {
         TableItem oldItem = resultsTable.getItem(i);
+        String filename = oldItem.getText(CURRENT_FILE_COLUMN);
+        FileEpisode episode = files.get(filename);
+
         boolean wasChecked = oldItem.getChecked();
         int oldStyle = oldItem.getStyle();
 
         TableItem item = new TableItem(resultsTable, oldStyle, j);
+        if (episode != null) {
+            episode.setViewItem(null);
+            episode.setViewItem(item);
+        }
         item.setChecked(wasChecked);
         item.setText(CURRENT_FILE_COLUMN, oldItem.getText(CURRENT_FILE_COLUMN));
         item.setText(NEW_FILENAME_COLUMN, oldItem.getText(NEW_FILENAME_COLUMN));


### PR DESCRIPTION
Each line in the TVRenamer table should be mapped to exactly one unique instance of a FileEpisode.  In the current codebase, the link is somewhat tenuous.  The file's path is entered into the TableItem, and there is a hash table that maps file paths to FileEpisodes.

So to go from a TableItem to its FileEpisode, you have to look up its text, and look up that text in the hash map.

To go in the opposite direction is trickier.  The only way to do it would be to iterate over either the hash map looking for an entry where the key is equal.

I think it makes sense to stash the TableItem right in the instance of the FileEpisode.  This will be useful when something about the FileEpisode changes, like when the file is moved.  Right now, we pass the TableItem as a separate argument to the FileMover, so that we still have it when the move happens, and we can update the UI.  If the TableItem were included in the FileEpisode, it would be one less thing to have to pass around.