### PR TITLE
Several improvements to tests

### DIFF
--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -69,7 +69,7 @@ public class TheTVDBProvider {
         try {
             DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
 
-            logger.info("About to retrieve search results from " + searchURL);
+            logger.fine("About to retrieve search results from " + searchURL);
 
             String searchXml = new HttpConnectionHandler().downloadUrl(searchURL);
 
@@ -110,7 +110,7 @@ public class TheTVDBProvider {
     public static void getShowListing(Show show) throws TVRenamerIOException {
         String showURL = BASE_LIST_URL + show.getId() + BASE_LIST_FILENAME;
 
-        logger.info("Retrieving episode listing from " + showURL);
+        logger.fine("Retrieving episode listing from " + showURL);
 
         DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
         String showXml;

--- a/src/main/org/tvrenamer/model/ShowStore.java
+++ b/src/main/org/tvrenamer/model/ShowStore.java
@@ -139,7 +139,7 @@ public class ShowStore {
      *            the {@link Show}
      */
     static void addShow(String showName, Show show) {
-        logger.info("Show listing for '" + show.getName() + "' downloaded");
+        logger.fine("Show listing for '" + show.getName() + "' downloaded");
         _shows.put(showName.toLowerCase(), show);
         notifyListeners(showName, show);
     }

--- a/src/test/org/tvrenamer/controller/TVRenamerTest.java
+++ b/src/test/org/tvrenamer/controller/TVRenamerTest.java
@@ -16,118 +16,95 @@ public class TVRenamerTest {
 
     @BeforeClass
     public static void setupValues() {
-        values.add(new TestInput("game.of.thrones.5x01.mp4", "game of thrones", "5", "1",
-                                 "The Wars to Come", ""));
-        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1",
-                                 "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
-        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18",
-                                 "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
+        values.add(new TestInput("game.of.thrones.5x01.mp4", "game of thrones", "5", "1", ""));
+        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1", "720p"));
+        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18", "720p"));
         values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010",
-                                 "1", "2", "Rewind", "720p"));
-        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide",
-                                 "720p"));
-        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1",
-                                 "Hail and Farewell, Part II (2)", ""));
+                                 "1", "2", "720p"));
+        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "720p"));
+        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1", ""));
         values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6",
-                                 "5", "Lighthouse", "720p"));
+                                 "5", "720p"));
         values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1",
-                                 "1", "Pilot", "720p"));
-        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14",
-                                 "Family Affair", ""));
-        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15",
-                                 "The Sixteen Year Old Virgin", ""));
-        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14",
-                                 "Conspiracy", ""));
-        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape",
-                                 ""));
+                                 "1", "720p"));
+        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14", ""));
+        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15", ""));
+        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14", ""));
+        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", ""));
         values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv",
-                                 "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
+                                 "the big bang theory", "3", "18", "720p"));
         values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9",
-                                 "Little Girl Lost", "720p"));
-        values.add(new TestInput("/TV/Dexter/S05E05 First Blood.mkv", "dexter", "5", "5", "First Blood", ""));
-        values.add(new TestInput("/TV/Lost/Lost [2x07].mkv", "lost", "2", "7", "The Other 48 Days", ""));
-        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17",
-                                 "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
-        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4",
-                                 "Dicks", ""));
-        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "continuum", "3", "7",
-                                 "Waning Minutes", ""));
-        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "elementary", "2", "23",
-                                 "Art in the Blood", ""));
-        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19",
-                                 "Meg Stinks!", ""));
-        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "fargo", "1", "1",
-                                 "The Crocodile's Dilemma", ""));
-        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "girls", "3", "11", "I Saw You", ""));
-        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "grimm", "3", "19",
-                                 "Nobody Knows the Trubel I've Seen", ""));
+                                 "720p"));
+        values.add(new TestInput("/TV/Dexter/S05E05 First Blood.mkv", "dexter", "5", "5", ""));
+        values.add(new TestInput("/TV/Lost/Lost [2x07].mkv", "lost", "2", "7", ""));
+        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17", ""));
+        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4", ""));
+        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "continuum", "3", "7", ""));
+        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "elementary", "2", "23", ""));
+        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19", ""));
+        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "fargo", "1", "1", ""));
+        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "girls", "3", "11", ""));
+        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "grimm", "3", "19", ""));
         values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "house of cards 2013",
-                                 "1", "6", "Chapter 6", ""));
+                                 "1", "6", ""));
         values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "modern family", "5",
-                                 "12", "Under Pressure", ""));
-        values.add(new TestInput("New.Girl.S03E23.HDTV.x264-LOL.mp4", "new girl", "3", "23", "Cruise", ""));
-        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "nurse jackie", "6", "4",
-                                 "Jungle Love", ""));
-        values.add(new TestInput("Offspring - S05E01.mp4", "offspring", "5", "1", "Back in the Game", ""));
-        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "reign 2013", "1", "20",
-                                 "Higher Ground", ""));
+                                 "12", ""));
+        values.add(new TestInput("New.Girl.S03E23.HDTV.x264-LOL.mp4", "new girl", "3", "23", ""));
+        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "nurse jackie", "6", "4", ""));
+        values.add(new TestInput("Offspring - S05E01.mp4", "offspring", "5", "1", ""));
+        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "reign 2013", "1", "20", ""));
         values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "robot chicken", "7",
-                                 "4", "Rebel Appliance", ""));
-        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "supernatural", "9", "21",
-                                 "King of the Damned", ""));
+                                 "4", ""));
+        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "supernatural", "9", "21", ""));
         values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "the americans 2013", "2",
-                                 "10", "Yousaf", ""));
+                                 "10", ""));
         values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "the big bang theory",
-                                 "7", "23", "The Gorilla Dissolution", ""));
-        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "the good wife", "5", "20",
-                                 "The Deep Web", ""));
+                                 "7", "23", ""));
+        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "the good wife", "5", "20", ""));
         values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "the walking dead",
-                                 "4", "16", "A", ""));
-        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "veep", "3", "5", "Fishing", ""));
+                                 "4", "16", ""));
+        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "veep", "3", "5", ""));
         values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4",
-                                 "witches of east end", "1", "1", "Pilot", ""));
-        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "warehouse 13", "5", "4",
-                                 "Savage Seduction", ""));
-        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "the 100", "2", "8", "Spacewalker", ""));
-        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "firefly", "1", "1", "Serenity", ""));
-        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "firefly", "1", "2", "The Train Job", ""));
-        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "firefly", "1", "3", "Bushwhacked", ""));
-        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "firefly", "1", "4", "Shindig", ""));
-        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "firefly", "1", "5", "Safe", ""));
-        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "firefly", "1", "6", "Our Mrs. Reynolds", ""));
-        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "firefly", "1", "7", "Jaynestown", ""));
-        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "firefly", "1", "8", "Out of Gas", ""));
-        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "firefly", "1", "9", "Ariel", ""));
-        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "firefly", "1", "10", "War Stories", ""));
-        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "firefly", "1", "11", "Trash", ""));
-        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "firefly", "1", "12", "The Message", ""));
-        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "firefly", "1", "13", "Heart of Gold", ""));
-        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "firefly", "1", "14", "Objects in Space", ""));
+                                 "witches of east end", "1", "1", ""));
+        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "warehouse 13", "5", "4", ""));
+        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "the 100", "2", "8", ""));
+        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "firefly", "1", "1", ""));
+        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "firefly", "1", "2", ""));
+        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "firefly", "1", "3", ""));
+        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "firefly", "1", "4", ""));
+        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "firefly", "1", "5", ""));
+        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "firefly", "1", "6", ""));
+        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "firefly", "1", "7", ""));
+        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "firefly", "1", "8", ""));
+        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "firefly", "1", "9", ""));
+        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "firefly", "1", "10", ""));
+        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "firefly", "1", "11", ""));
+        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "firefly", "1", "12", ""));
+        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "firefly", "1", "13", ""));
+        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "firefly", "1", "14", ""));
         values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "strike back", "1",
-                                 "1", "Chris Ryan's Strike Back, Episode 1", "720p"));
-        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "law and order svu", "17", "05",
-                                 "Community Policing", ""));
-        values.add(new TestInput("ncis.1304.hdtv-lol", "ncis", "13", "04", "Double Trouble", ""));
+                                 "1", "720p"));
+        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "law and order svu", "17", "05", ""));
+        values.add(new TestInput("ncis.1304.hdtv-lol", "ncis", "13", "04", ""));
         values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET",
-                                 "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
+                                 "marvels agents of shield", "3", "3", ""));
         values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS",
-                                 "marvels agents of shield", "3", "10", "Maveth", ""));
+                                 "marvels agents of shield", "3", "10", ""));
         values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1",
-                                 "Don Hoberman", "720p"));
+                                 "720p"));
         values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv",
-                                 "the big bang theory", "10", "4", "The Cohabitation Experimentation", "720p"));
+                                 "the big bang theory", "10", "4", "720p"));
         values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "lucifer", "2", "3",
-                                 "Sin-Eater", "720p"));
+                                 "720p"));
         values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv",
-                                 "marvels agents of shield", "4", "3", "Uprising", "1080p"));
+                                 "marvels agents of shield", "4", "3", "1080p"));
         values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "supernatural",
-                                 "11", "22", "We Happy Few", "1080p"));
+                                 "11", "22", "1080p"));
         values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "supernatural",
-                                 "11", "22", "We Happy Few", "720p"));
+                                 "11", "22", "720p"));
         values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "channel zero",
-                                 "1", "1", "You Have to Go Inside", "480p"));
-        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "ncis", "14", "4",
-                                 "Love Boat", "720p"));
+                                 "1", "1", "480p"));
+        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "ncis", "14", "4", "720p"));
     }
 
     @Test
@@ -179,18 +156,15 @@ public class TVRenamerTest {
         public final String show;
         public final String season;
         public final String episode;
-
-        public final String episodeTitle;
         public final String episodeResolution;
 
-        public TestInput(String input, String show, String season, String episode, String episodeTitle,
+        public TestInput(String input, String show, String season, String episode,
                          String episodeResolution)
         {
             this.input = input;
             this.show = show.toLowerCase();
             this.season = season;
             this.episode = episode;
-            this.episodeTitle = episodeTitle;
             this.episodeResolution = episodeResolution;
         }
     }

--- a/src/test/org/tvrenamer/controller/TVRenamerTest.java
+++ b/src/test/org/tvrenamer/controller/TVRenamerTest.java
@@ -2,19 +2,14 @@ package org.tvrenamer.controller;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.fail;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.tvrenamer.model.FileEpisode;
-import org.tvrenamer.model.Show;
-import org.tvrenamer.model.ShowStore;
 
 import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 public class TVRenamerTest {
     public static final List<TestInput> values = new LinkedList<>();
@@ -141,43 +136,6 @@ public class TVRenamerTest {
         assertEquals(4, episode.getEpisodeNumber());
     }
 
-    @Test
-    public void testDownloadAndRename() {
-        for (TestInput testInput : values) {
-            if (testInput.episodeTitle != null) {
-                final String filename = testInput.input;
-                try {
-                    final FileEpisode fileEpisode = TVRenamer.parseFilename(filename);
-                    assertNotNull(fileEpisode);
-                    String showName = fileEpisode.getShowName();
-
-                    final CompletableFuture<String> future = new CompletableFuture<>();
-                    ShowStore.getShow(showName, new ShowInformationListener() {
-                        @Override
-                        public void downloaded(Show show) {
-                            future.complete(show.getSeason(fileEpisode.getSeasonNumber()).getTitle(fileEpisode.getEpisodeNumber()));
-                        }
-
-                        @Override
-                        public void downloadFailed(Show show) {
-                            future.complete(null);
-                        }
-                    });
-
-                    String got = future.get(15, TimeUnit.SECONDS);
-                    assertEquals(testInput.episodeTitle, got);
-                } catch (Exception e) {
-                    String failMsg = "failure (likely timeout) trying to query for " + filename;
-                    String exceptionMessage = e.getMessage();
-                    if (exceptionMessage != null) {
-                        failMsg += ": " + exceptionMessage;
-                    }
-                    fail(failMsg);
-                }
-            }
-        }
-    }
-
     private static class TestInput {
         public final String input;
         public final String show;
@@ -196,5 +154,4 @@ public class TVRenamerTest {
             this.episodeResolution = episodeResolution;
         }
     }
-
 }

--- a/src/test/org/tvrenamer/controller/TVRenamerTest.java
+++ b/src/test/org/tvrenamer/controller/TVRenamerTest.java
@@ -16,80 +16,118 @@ public class TVRenamerTest {
 
     @BeforeClass
     public static void setupValues() {
-        values.add(new TestInput("game.of.thrones.5x01.mp4", "Game of Thrones", "5", "1", "The Wars to Come", ""));
-        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1", "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
-        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18", "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
-        values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010", "1", "2", "Rewind", "720p"));
-        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide", "720p"));
-        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1", "Hail and Farewell, Part II (2)", ""));
-        values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6", "5", "Lighthouse", "720p"));
-        values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1", "1", "Pilot", "720p"));
-        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14", "Family Affair", ""));
-        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15", "The Sixteen Year Old Virgin", ""));
-        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14", "Conspiracy", ""));
-        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape", ""));
-        values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv", "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
-        values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9", "Little Girl Lost", "720p"));
+        values.add(new TestInput("game.of.thrones.5x01.mp4", "game of thrones", "5", "1",
+                                 "The Wars to Come", ""));
+        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1",
+                                 "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
+        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18",
+                                 "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
+        values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010",
+                                 "1", "2", "Rewind", "720p"));
+        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide",
+                                 "720p"));
+        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1",
+                                 "Hail and Farewell, Part II (2)", ""));
+        values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6",
+                                 "5", "Lighthouse", "720p"));
+        values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1",
+                                 "1", "Pilot", "720p"));
+        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14",
+                                 "Family Affair", ""));
+        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15",
+                                 "The Sixteen Year Old Virgin", ""));
+        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14",
+                                 "Conspiracy", ""));
+        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape",
+                                 ""));
+        values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv",
+                                 "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
+        values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9",
+                                 "Little Girl Lost", "720p"));
         values.add(new TestInput("/TV/Dexter/S05E05 First Blood.mkv", "dexter", "5", "5", "First Blood", ""));
         values.add(new TestInput("/TV/Lost/Lost [2x07].mkv", "lost", "2", "7", "The Other 48 Days", ""));
-
-        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17", "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
-        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4", "Dicks", ""));
-        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "Continuum", "3", "7", "Waning Minutes", ""));
-        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "Elementary", "2", "23", "Art in the Blood", ""));
-        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19", "Meg Stinks!", ""));
-        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "Fargo", "1", "1", "The Crocodile's Dilemma", ""));
-        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "Girls", "3", "11", "I Saw You", ""));
-        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "Grimm", "3", "19", "Nobody Knows the Trubel I've Seen", ""));
-        values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "House Of Cards 2013", "1", "6", "Chapter 6", ""));
-        values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "Modern Family", "5", "12", "Under Pressure", ""));
+        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17",
+                                 "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
+        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4",
+                                 "Dicks", ""));
+        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "continuum", "3", "7",
+                                 "Waning Minutes", ""));
+        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "elementary", "2", "23",
+                                 "Art in the Blood", ""));
+        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19",
+                                 "Meg Stinks!", ""));
+        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "fargo", "1", "1",
+                                 "The Crocodile's Dilemma", ""));
+        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "girls", "3", "11", "I Saw You", ""));
+        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "grimm", "3", "19",
+                                 "Nobody Knows the Trubel I've Seen", ""));
+        values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "house of cards 2013",
+                                 "1", "6", "Chapter 6", ""));
+        values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "modern family", "5",
+                                 "12", "Under Pressure", ""));
         values.add(new TestInput("New.Girl.S03E23.HDTV.x264-LOL.mp4", "new girl", "3", "23", "Cruise", ""));
-        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "Nurse Jackie", "6", "4", "Jungle Love", ""));
-        values.add(new TestInput("Offspring - S05E01.mp4", "Offspring", "5", "1", "Back in the Game", ""));
-        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "Reign 2013", "1", "20", "Higher Ground", ""));
-        values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "Robot Chicken", "7", "4", "Rebel Appliance", ""));
-        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "Supernatural", "9", "21", "King of the Damned", ""));
-        values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "The Americans 2013", "2", "10", "Yousaf", ""));
-        values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "The Big Bang Theory", "7", "23", "The Gorilla Dissolution", ""));
-        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "The Good Wife", "5", "20", "The Deep Web", ""));
-        values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "The Walking Dead", "4", "16", "A", ""));
-        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "Veep", "3", "5", "Fishing", ""));
-        values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4", "Witches of East End", "1", "1", "Pilot", ""));
-        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "Warehouse 13", "5", "4", "Savage Seduction", ""));
-
-        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "The 100", "2", "8", "Spacewalker", "")); // issue #79
-
-        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "Firefly", "1", "1", "Serenity", ""));
-        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "Firefly", "1", "2", "The Train Job", ""));
-        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "Firefly", "1", "3", "Bushwhacked", ""));
-        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "Firefly", "1", "4", "Shindig", ""));
-        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "Firefly", "1", "5", "Safe", ""));
-        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "Firefly", "1", "6", "Our Mrs. Reynolds", ""));
-        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "Firefly", "1", "7", "Jaynestown", ""));
-        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "Firefly", "1", "8", "Out of Gas", ""));
-        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "Firefly", "1", "9", "Ariel", ""));
-        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "Firefly", "1", "10", "War Stories", ""));
-        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "Firefly", "1", "11", "Trash", ""));
-        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "Firefly", "1", "12", "The Message", ""));
-        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "Firefly", "1", "13", "Heart of Gold", ""));
-        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "Firefly", "1", "14", "Objects in Space", ""));
-
-        values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "Strike Back", "1", "1",
-                                 "Chris Ryan's Strike Back, Episode 1", "720p"));
-
-        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "Law and Order SVU", "17", "05", "Community Policing", ""));
-        values.add(new TestInput("ncis.1304.hdtv-lol", "NCIS", "13", "04", "Double Trouble", ""));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET", "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS", "marvels agents of shield", "3", "10", "Maveth", ""));
-        values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1", "Don Hoberman", "720p"));
-
-        values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "The Big Bang Theory", "10", "4", "The Cohabitation Experimentation", "720p"));
-        values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "Lucifer", "2", "3", "Sin-Eater", "720p"));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv", "Marvels Agents of SHIELD", "4", "3", "Uprising", "1080p"));
-        values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "Supernatural", "11", "22", "We Happy Few", "1080p"));
-        values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "Supernatural", "11", "22", "We Happy Few", "720p"));
-        values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "Channel Zero", "1", "1", "You Have to Go Inside", "480p"));
-        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "NCIS", "14", "4", "Love Boat", "720p"));
+        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "nurse jackie", "6", "4",
+                                 "Jungle Love", ""));
+        values.add(new TestInput("Offspring - S05E01.mp4", "offspring", "5", "1", "Back in the Game", ""));
+        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "reign 2013", "1", "20",
+                                 "Higher Ground", ""));
+        values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "robot chicken", "7",
+                                 "4", "Rebel Appliance", ""));
+        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "supernatural", "9", "21",
+                                 "King of the Damned", ""));
+        values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "the americans 2013", "2",
+                                 "10", "Yousaf", ""));
+        values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "the big bang theory",
+                                 "7", "23", "The Gorilla Dissolution", ""));
+        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "the good wife", "5", "20",
+                                 "The Deep Web", ""));
+        values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "the walking dead",
+                                 "4", "16", "A", ""));
+        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "veep", "3", "5", "Fishing", ""));
+        values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4",
+                                 "witches of east end", "1", "1", "Pilot", ""));
+        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "warehouse 13", "5", "4",
+                                 "Savage Seduction", ""));
+        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "the 100", "2", "8", "Spacewalker", ""));
+        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "firefly", "1", "1", "Serenity", ""));
+        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "firefly", "1", "2", "The Train Job", ""));
+        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "firefly", "1", "3", "Bushwhacked", ""));
+        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "firefly", "1", "4", "Shindig", ""));
+        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "firefly", "1", "5", "Safe", ""));
+        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "firefly", "1", "6", "Our Mrs. Reynolds", ""));
+        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "firefly", "1", "7", "Jaynestown", ""));
+        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "firefly", "1", "8", "Out of Gas", ""));
+        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "firefly", "1", "9", "Ariel", ""));
+        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "firefly", "1", "10", "War Stories", ""));
+        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "firefly", "1", "11", "Trash", ""));
+        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "firefly", "1", "12", "The Message", ""));
+        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "firefly", "1", "13", "Heart of Gold", ""));
+        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "firefly", "1", "14", "Objects in Space", ""));
+        values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "strike back", "1",
+                                 "1", "Chris Ryan's Strike Back, Episode 1", "720p"));
+        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "law and order svu", "17", "05",
+                                 "Community Policing", ""));
+        values.add(new TestInput("ncis.1304.hdtv-lol", "ncis", "13", "04", "Double Trouble", ""));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET",
+                                 "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS",
+                                 "marvels agents of shield", "3", "10", "Maveth", ""));
+        values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1",
+                                 "Don Hoberman", "720p"));
+        values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv",
+                                 "the big bang theory", "10", "4", "The Cohabitation Experimentation", "720p"));
+        values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "lucifer", "2", "3",
+                                 "Sin-Eater", "720p"));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv",
+                                 "marvels agents of shield", "4", "3", "Uprising", "1080p"));
+        values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "supernatural",
+                                 "11", "22", "We Happy Few", "1080p"));
+        values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "supernatural",
+                                 "11", "22", "We Happy Few", "720p"));
+        values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "channel zero",
+                                 "1", "1", "You Have to Go Inside", "480p"));
+        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "ncis", "14", "4",
+                                 "Love Boat", "720p"));
     }
 
     @Test
@@ -145,7 +183,9 @@ public class TVRenamerTest {
         public final String episodeTitle;
         public final String episodeResolution;
 
-        public TestInput(String input, String show, String season, String episode, String episodeTitle, String episodeResolution) {
+        public TestInput(String input, String show, String season, String episode, String episodeTitle,
+                         String episodeResolution)
+        {
             this.input = input;
             this.show = show.toLowerCase();
             this.season = season;

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -1,12 +1,163 @@
 package org.tvrenamer.controller;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
+
+import org.tvrenamer.model.FileEpisode;
 import org.tvrenamer.model.Show;
+import org.tvrenamer.model.ShowStore;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 public class TheTVDBProviderTest {
+
+    private static class TestInput {
+        public final String input;
+        public final String show;
+        public final String season;
+        public final String episode;
+
+        public final String episodeTitle;
+        public final String episodeResolution;
+
+        public TestInput(String input, String show, String season, String episode, String episodeTitle, String episodeResolution) {
+            this.input = input;
+            this.show = show.toLowerCase();
+            this.season = season;
+            this.episode = episode;
+            this.episodeTitle = episodeTitle;
+            this.episodeResolution = episodeResolution;
+        }
+    }
+
+
+    public static final List<TestInput> values = new LinkedList<>();
+
+    @BeforeClass
+    public static void setupValues() {
+        values.add(new TestInput("game.of.thrones.5x01.mp4", "Game of Thrones", "5", "1", "The Wars to Come", ""));
+        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1", "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
+        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18", "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
+        values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010", "1", "2", "Rewind", "720p"));
+        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide", "720p"));
+        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1", "Hail and Farewell, Part II (2)", ""));
+        values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6", "5", "Lighthouse", "720p"));
+        values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1", "1", "Pilot", "720p"));
+        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14", "Family Affair", ""));
+        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15", "The Sixteen Year Old Virgin", ""));
+        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14", "Conspiracy", ""));
+        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape", ""));
+        values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv", "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
+        values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9", "Little Girl Lost", "720p"));
+        values.add(new TestInput("/TV/Dexter/S05E05 First Blood.mkv", "dexter", "5", "5", "First Blood", ""));
+        values.add(new TestInput("/TV/Lost/Lost [2x07].mkv", "lost", "2", "7", "The Other 48 Days", ""));
+
+        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17", "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
+        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4", "Dicks", ""));
+        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "Continuum", "3", "7", "Waning Minutes", ""));
+        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "Elementary", "2", "23", "Art in the Blood", ""));
+        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19", "Meg Stinks!", ""));
+        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "Fargo", "1", "1", "The Crocodile's Dilemma", ""));
+        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "Girls", "3", "11", "I Saw You", ""));
+        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "Grimm", "3", "19", "Nobody Knows the Trubel I've Seen", ""));
+        values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "House Of Cards 2013", "1", "6", "Chapter 6", ""));
+        values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "Modern Family", "5", "12", "Under Pressure", ""));
+        values.add(new TestInput("New.Girl.S03E23.HDTV.x264-LOL.mp4", "new girl", "3", "23", "Cruise", ""));
+        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "Nurse Jackie", "6", "4", "Jungle Love", ""));
+        values.add(new TestInput("Offspring - S05E01.mp4", "Offspring", "5", "1", "Back in the Game", ""));
+        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "Reign 2013", "1", "20", "Higher Ground", ""));
+        values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "Robot Chicken", "7", "4", "Rebel Appliance", ""));
+        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "Supernatural", "9", "21", "King of the Damned", ""));
+        values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "The Americans 2013", "2", "10", "Yousaf", ""));
+        values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "The Big Bang Theory", "7", "23", "The Gorilla Dissolution", ""));
+        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "The Good Wife", "5", "20", "The Deep Web", ""));
+        values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "The Walking Dead", "4", "16", "A", ""));
+        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "Veep", "3", "5", "Fishing", ""));
+        values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4", "Witches of East End", "1", "1", "Pilot", ""));
+        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "Warehouse 13", "5", "4", "Savage Seduction", ""));
+
+        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "The 100", "2", "8", "Spacewalker", "")); // issue #79
+
+        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "Firefly", "1", "1", "Serenity", ""));
+        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "Firefly", "1", "2", "The Train Job", ""));
+        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "Firefly", "1", "3", "Bushwhacked", ""));
+        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "Firefly", "1", "4", "Shindig", ""));
+        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "Firefly", "1", "5", "Safe", ""));
+        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "Firefly", "1", "6", "Our Mrs. Reynolds", ""));
+        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "Firefly", "1", "7", "Jaynestown", ""));
+        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "Firefly", "1", "8", "Out of Gas", ""));
+        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "Firefly", "1", "9", "Ariel", ""));
+        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "Firefly", "1", "10", "War Stories", ""));
+        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "Firefly", "1", "11", "Trash", ""));
+        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "Firefly", "1", "12", "The Message", ""));
+        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "Firefly", "1", "13", "Heart of Gold", ""));
+        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "Firefly", "1", "14", "Objects in Space", ""));
+
+        values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "Strike Back", "1", "1",
+                                 "Chris Ryan's Strike Back, Episode 1", "720p"));
+
+        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "Law and Order SVU", "17", "05", "Community Policing", ""));
+        values.add(new TestInput("ncis.1304.hdtv-lol", "NCIS", "13", "04", "Double Trouble", ""));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET", "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS", "marvels agents of shield", "3", "10", "Maveth", ""));
+        values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1", "Don Hoberman", "720p"));
+
+        values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "The Big Bang Theory", "10", "4", "The Cohabitation Experimentation", "720p"));
+        values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "Lucifer", "2", "3", "Sin-Eater", "720p"));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv", "Marvels Agents of SHIELD", "4", "3", "Uprising", "1080p"));
+        values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "Supernatural", "11", "22", "We Happy Few", "1080p"));
+        values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "Supernatural", "11", "22", "We Happy Few", "720p"));
+        values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "Channel Zero", "1", "1", "You Have to Go Inside", "480p"));
+        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "NCIS", "14", "4", "Love Boat", "720p"));
+    }
+
+    @Test
+    public void testDownloadAndRename() {
+        for (TestInput testInput : values) {
+            if (testInput.episodeTitle != null) {
+                final String filename = testInput.input;
+                try {
+                    final FileEpisode fileEpisode = TVRenamer.parseFilename(filename);
+                    assertNotNull(fileEpisode);
+                    String showName = fileEpisode.getShowName();
+
+                    final CompletableFuture<String> future = new CompletableFuture<>();
+                    ShowStore.getShow(showName, new ShowInformationListener() {
+                        @Override
+                        public void downloaded(Show show) {
+                            future.complete(show.getSeason(fileEpisode.getSeasonNumber()).getTitle(fileEpisode.getEpisodeNumber()));
+                        }
+
+                        @Override
+                        public void downloadFailed(Show show) {
+                            future.complete(null);
+                        }
+                    });
+
+                    String got = future.get(15, TimeUnit.SECONDS);
+                    assertEquals(testInput.episodeTitle, got);
+                } catch (Exception e) {
+                    String failMsg = "failure trying to query for " + filename
+                        + e.getClass().getName() + " ";
+                    String exceptionMessage = e.getMessage();
+                    if (exceptionMessage != null) {
+                        failMsg += exceptionMessage;
+                    } else {
+                        failMsg += "(likely timeout)";
+                    }
+                    fail(failMsg);
+                }
+            }
+        }
+    }
 
     @Test
     public void testGetShowOptions() throws Exception {

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.fail;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import org.tvrenamer.model.FileEpisode;
 import org.tvrenamer.model.Show;
 import org.tvrenamer.model.ShowStore;
 
@@ -20,161 +19,107 @@ import java.util.concurrent.TimeUnit;
 public class TheTVDBProviderTest {
 
     private static class TestInput {
-        public final String input;
         public final String show;
         public final String season;
         public final String episode;
-
         public final String episodeTitle;
-        public final String episodeResolution;
 
-        public TestInput(String input, String show, String season, String episode, String episodeTitle,
-                         String episodeResolution)
-        {
-            this.input = input;
+        public TestInput(String show, String season, String episode, String episodeTitle) {
             this.show = show.toLowerCase();
             this.season = season;
             this.episode = episode;
             this.episodeTitle = episodeTitle;
-            this.episodeResolution = episodeResolution;
         }
     }
-
 
     public static final List<TestInput> values = new LinkedList<>();
 
     @BeforeClass
     public static void setupValues() {
-        values.add(new TestInput("game.of.thrones.5x01.mp4", "game of thrones", "5", "1",
-                                 "The Wars to Come", ""));
-        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1",
-                                 "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
-        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18",
-                                 "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
-        values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010",
-                                 "1", "2", "Rewind", "720p"));
-        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide",
-                                 "720p"));
-        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1",
-                                 "Hail and Farewell, Part II (2)", ""));
-        values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6",
-                                 "5", "Lighthouse", "720p"));
-        values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1",
-                                 "1", "Pilot", "720p"));
-        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14",
-                                 "Family Affair", ""));
-        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15",
-                                 "The Sixteen Year Old Virgin", ""));
-        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14",
-                                 "Conspiracy", ""));
-        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape",
-                                 ""));
-        values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv",
-                                 "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
-        values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9",
-                                 "Little Girl Lost", "720p"));
-        values.add(new TestInput("/TV/Dexter/S05E05 First Blood.mkv", "dexter", "5", "5", "First Blood", ""));
-        values.add(new TestInput("/TV/Lost/Lost [2x07].mkv", "lost", "2", "7", "The Other 48 Days", ""));
-        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17",
-                                 "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
-        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4",
-                                 "Dicks", ""));
-        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "continuum", "3", "7",
-                                 "Waning Minutes", ""));
-        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "elementary", "2", "23",
-                                 "Art in the Blood", ""));
-        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19",
-                                 "Meg Stinks!", ""));
-        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "fargo", "1", "1",
-                                 "The Crocodile's Dilemma", ""));
-        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "girls", "3", "11", "I Saw You", ""));
-        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "grimm", "3", "19",
-                                 "Nobody Knows the Trubel I've Seen", ""));
-        values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "house of cards 2013",
-                                 "1", "6", "Chapter 6", ""));
-        values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "modern family", "5",
-                                 "12", "Under Pressure", ""));
-        values.add(new TestInput("New.Girl.S03E23.HDTV.x264-LOL.mp4", "new girl", "3", "23", "Cruise", ""));
-        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "nurse jackie", "6", "4",
-                                 "Jungle Love", ""));
-        values.add(new TestInput("Offspring - S05E01.mp4", "offspring", "5", "1", "Back in the Game", ""));
-        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "reign 2013", "1", "20",
-                                 "Higher Ground", ""));
-        values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "robot chicken", "7",
-                                 "4", "Rebel Appliance", ""));
-        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "supernatural", "9", "21",
-                                 "King of the Damned", ""));
-        values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "the americans 2013", "2",
-                                 "10", "Yousaf", ""));
-        values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "the big bang theory",
-                                 "7", "23", "The Gorilla Dissolution", ""));
-        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "the good wife", "5", "20",
-                                 "The Deep Web", ""));
-        values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "the walking dead",
-                                 "4", "16", "A", ""));
-        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "veep", "3", "5", "Fishing", ""));
-        values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4",
-                                 "witches of east end", "1", "1", "Pilot", ""));
-        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "warehouse 13", "5", "4",
-                                 "Savage Seduction", ""));
-        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "the 100", "2", "8", "Spacewalker", ""));
-        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "firefly", "1", "1", "Serenity", ""));
-        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "firefly", "1", "2", "The Train Job", ""));
-        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "firefly", "1", "3", "Bushwhacked", ""));
-        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "firefly", "1", "4", "Shindig", ""));
-        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "firefly", "1", "5", "Safe", ""));
-        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "firefly", "1", "6", "Our Mrs. Reynolds", ""));
-        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "firefly", "1", "7", "Jaynestown", ""));
-        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "firefly", "1", "8", "Out of Gas", ""));
-        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "firefly", "1", "9", "Ariel", ""));
-        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "firefly", "1", "10", "War Stories", ""));
-        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "firefly", "1", "11", "Trash", ""));
-        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "firefly", "1", "12", "The Message", ""));
-        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "firefly", "1", "13", "Heart of Gold", ""));
-        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "firefly", "1", "14", "Objects in Space", ""));
-        values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "strike back", "1",
-                                 "1", "Chris Ryan's Strike Back, Episode 1", "720p"));
-        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "law and order svu", "17", "05",
-                                 "Community Policing", ""));
-        values.add(new TestInput("ncis.1304.hdtv-lol", "ncis", "13", "04", "Double Trouble", ""));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET",
-                                 "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS",
-                                 "marvels agents of shield", "3", "10", "Maveth", ""));
-        values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1",
-                                 "Don Hoberman", "720p"));
-        values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv",
-                                 "the big bang theory", "10", "4", "The Cohabitation Experimentation", "720p"));
-        values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "lucifer", "2", "3",
-                                 "Sin-Eater", "720p"));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv",
-                                 "marvels agents of shield", "4", "3", "Uprising", "1080p"));
-        values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "supernatural",
-                                 "11", "22", "We Happy Few", "1080p"));
-        values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "supernatural",
-                                 "11", "22", "We Happy Few", "720p"));
-        values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "channel zero",
-                                 "1", "1", "You Have to Go Inside", "480p"));
-        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "ncis", "14", "4",
-                                 "Love Boat", "720p"));
+        values.add(new TestInput("game of thrones", "5", "1", "The Wars to Come"));
+        values.add(new TestInput("24", "8", "1", "Day 8: 4:00 P.M. - 5:00 P.M."));
+        values.add(new TestInput("24", "7", "18", "Day 7: 1:00 A.M. - 2:00 A.M."));
+        values.add(new TestInput("human target 2010", "1", "2", "Rewind"));
+        values.add(new TestInput("dexter", "4", "7", "Slack Tide"));
+        values.add(new TestInput("jag", "10", "1", "Hail and Farewell, Part II (2)"));
+        values.add(new TestInput("lost", "6", "5", "Lighthouse"));
+        values.add(new TestInput("warehouse 13", "1", "1", "Pilot"));
+        values.add(new TestInput("one tree hill", "7", "14", "Family Affair"));
+        values.add(new TestInput("gossip girl", "3", "15", "The Sixteen Year Old Virgin"));
+        values.add(new TestInput("smallville", "9", "14", "Conspiracy"));
+        values.add(new TestInput("smallville", "9", "15", "Escape"));
+        values.add(new TestInput("the big bang theory", "3", "18", "The Pants Alternative"));
+        values.add(new TestInput("castle 2009", "1", "9", "Little Girl Lost"));
+        values.add(new TestInput("dexter", "5", "5", "First Blood"));
+        values.add(new TestInput("lost", "2", "7", "The Other 48 Days"));
+        values.add(new TestInput("american dad", "9", "17",
+                                 "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith"));
+        values.add(new TestInput("californication", "7", "4", "Dicks"));
+        values.add(new TestInput("continuum", "3", "7", "Waning Minutes"));
+        values.add(new TestInput("elementary", "2", "23", "Art in the Blood"));
+        values.add(new TestInput("family guy", "12", "19", "Meg Stinks!"));
+        values.add(new TestInput("fargo", "1", "1", "The Crocodile's Dilemma"));
+        values.add(new TestInput("girls", "3", "11", "I Saw You"));
+        values.add(new TestInput("grimm", "3", "19", "Nobody Knows the Trubel I've Seen"));
+        values.add(new TestInput("house of cards 2013", "1", "6", "Chapter 6"));
+        values.add(new TestInput("modern family", "5", "12", "Under Pressure"));
+        values.add(new TestInput("new girl", "3", "23", "Cruise"));
+        values.add(new TestInput("nurse jackie", "6", "4", "Jungle Love"));
+        values.add(new TestInput("offspring", "5", "1", "Back in the Game"));
+        values.add(new TestInput("reign 2013", "1", "20", "Higher Ground"));
+        values.add(new TestInput("robot chicken", "7", "4", "Rebel Appliance"));
+        values.add(new TestInput("supernatural", "9", "21", "King of the Damned"));
+        values.add(new TestInput("the americans 2013", "2", "10", "Yousaf"));
+        values.add(new TestInput("the big bang theory", "7", "23", "The Gorilla Dissolution"));
+        values.add(new TestInput("the good wife", "5", "20", "The Deep Web"));
+        values.add(new TestInput("the walking dead", "4", "16", "A"));
+        values.add(new TestInput("veep", "3", "5", "Fishing"));
+        values.add(new TestInput("witches of east end", "1", "1", "Pilot"));
+        values.add(new TestInput("warehouse 13", "5", "4", "Savage Seduction"));
+        values.add(new TestInput("the 100", "2", "8", "Spacewalker"));
+        values.add(new TestInput("firefly", "1", "1", "Serenity"));
+        values.add(new TestInput("firefly", "1", "2", "The Train Job"));
+        values.add(new TestInput("firefly", "1", "3", "Bushwhacked"));
+        values.add(new TestInput("firefly", "1", "4", "Shindig"));
+        values.add(new TestInput("firefly", "1", "5", "Safe"));
+        values.add(new TestInput("firefly", "1", "6", "Our Mrs. Reynolds"));
+        values.add(new TestInput("firefly", "1", "7", "Jaynestown"));
+        values.add(new TestInput("firefly", "1", "8", "Out of Gas"));
+        values.add(new TestInput("firefly", "1", "9", "Ariel"));
+        values.add(new TestInput("firefly", "1", "10", "War Stories"));
+        values.add(new TestInput("firefly", "1", "11", "Trash"));
+        values.add(new TestInput("firefly", "1", "12", "The Message"));
+        values.add(new TestInput("firefly", "1", "13", "Heart of Gold"));
+        values.add(new TestInput("firefly", "1", "14", "Objects in Space"));
+        values.add(new TestInput("strike back", "1", "1", "Chris Ryan's Strike Back, Episode 1"));
+        values.add(new TestInput("law and order svu", "17", "05", "Community Policing"));
+        values.add(new TestInput("ncis", "13", "04", "Double Trouble"));
+        values.add(new TestInput("marvels agents of shield", "3", "3", "A Wanted (Inhu)man"));
+        values.add(new TestInput("marvels agents of shield", "3", "10", "Maveth"));
+        values.add(new TestInput("nip tuck", "6", "1", "Don Hoberman"));
+        values.add(new TestInput("the big bang theory", "10", "4", "The Cohabitation Experimentation"));
+        values.add(new TestInput("lucifer", "2", "3", "Sin-Eater"));
+        values.add(new TestInput("marvels agents of shield", "4", "3", "Uprising"));
+        values.add(new TestInput("supernatural", "11", "22", "We Happy Few"));
+        values.add(new TestInput("channel zero", "1", "1", "You Have to Go Inside"));
+        values.add(new TestInput("ncis", "14", "4", "Love Boat"));
     }
 
     @Test
-    public void testDownloadAndRename() {
+    public void testGetEpisodeTitle() {
         for (TestInput testInput : values) {
             if (testInput.episodeTitle != null) {
-                final String filename = testInput.input;
+                final String showName = testInput.show;
+                final String season = testInput.season;
+                final String episode = testInput.episode;
                 try {
-                    final FileEpisode fileEpisode = TVRenamer.parseFilename(filename);
-                    assertNotNull(fileEpisode);
-                    String showName = fileEpisode.getShowName();
-
+                    final int seasonNum = Integer.parseInt(season);
+                    final int episodeNum = Integer.parseInt(episode);
                     final CompletableFuture<String> future = new CompletableFuture<>();
                     ShowStore.getShow(showName, new ShowInformationListener() {
                         @Override
                         public void downloaded(Show show) {
-                            future.complete(show.getSeason(fileEpisode.getSeasonNumber())
-                                            .getTitle(fileEpisode.getEpisodeNumber()));
+                            future.complete(show.getSeason(seasonNum).getTitle(episodeNum));
                         }
 
                         @Override
@@ -186,7 +131,8 @@ public class TheTVDBProviderTest {
                     String got = future.get(15, TimeUnit.SECONDS);
                     assertEquals(testInput.episodeTitle, got);
                 } catch (Exception e) {
-                    String failMsg = "failure trying to query for " + filename
+                    String failMsg = "failure trying to query for " + showName
+                        + ", season " + season + ", " + episode
                         + e.getClass().getName() + " ";
                     String exceptionMessage = e.getMessage();
                     if (exceptionMessage != null) {

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -28,7 +28,9 @@ public class TheTVDBProviderTest {
         public final String episodeTitle;
         public final String episodeResolution;
 
-        public TestInput(String input, String show, String season, String episode, String episodeTitle, String episodeResolution) {
+        public TestInput(String input, String show, String season, String episode, String episodeTitle,
+                         String episodeResolution)
+        {
             this.input = input;
             this.show = show.toLowerCase();
             this.season = season;
@@ -43,80 +45,118 @@ public class TheTVDBProviderTest {
 
     @BeforeClass
     public static void setupValues() {
-        values.add(new TestInput("game.of.thrones.5x01.mp4", "Game of Thrones", "5", "1", "The Wars to Come", ""));
-        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1", "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
-        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18", "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
-        values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010", "1", "2", "Rewind", "720p"));
-        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide", "720p"));
-        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1", "Hail and Farewell, Part II (2)", ""));
-        values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6", "5", "Lighthouse", "720p"));
-        values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1", "1", "Pilot", "720p"));
-        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14", "Family Affair", ""));
-        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15", "The Sixteen Year Old Virgin", ""));
-        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14", "Conspiracy", ""));
-        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape", ""));
-        values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv", "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
-        values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9", "Little Girl Lost", "720p"));
+        values.add(new TestInput("game.of.thrones.5x01.mp4", "game of thrones", "5", "1",
+                                 "The Wars to Come", ""));
+        values.add(new TestInput("24.s08.e01.720p.hdtv.x264-immerse.mkv", "24", "8", "1",
+                                 "Day 8: 4:00 P.M. - 5:00 P.M.", "720p"));
+        values.add(new TestInput("24.S07.E18.720p.BlueRay.x264-SiNNERS.mkv", "24", "7", "18",
+                                 "Day 7: 1:00 A.M. - 2:00 A.M.", "720p"));
+        values.add(new TestInput("human.target.2010.s01.e02.720p.hdtv.x264-2hd.mkv", "human target 2010",
+                                 "1", "2", "Rewind", "720p"));
+        values.add(new TestInput("dexter.407.720p.hdtv.x264-sys.mkv", "dexter", "4", "7", "Slack Tide",
+                                 "720p"));
+        values.add(new TestInput("JAG.S10E01.DVDRip.XviD-P0W4DVD.avi", "jag", "10", "1",
+                                 "Hail and Farewell, Part II (2)", ""));
+        values.add(new TestInput("Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv", "lost", "6",
+                                 "5", "Lighthouse", "720p"));
+        values.add(new TestInput("warehouse.13.s1e01.720p.hdtv.x264-dimension.mkv", "warehouse 13", "1",
+                                 "1", "Pilot", "720p"));
+        values.add(new TestInput("one.tree.hill.s07e14.hdtv.xvid-fqm.avi", "one tree hill", "7", "14",
+                                 "Family Affair", ""));
+        values.add(new TestInput("gossip.girl.s03e15.hdtv.xvid-fqm.avi", "gossip girl", "3", "15",
+                                 "The Sixteen Year Old Virgin", ""));
+        values.add(new TestInput("smallville.s09e14.hdtv.xvid-xii.avi", "smallville", "9", "14",
+                                 "Conspiracy", ""));
+        values.add(new TestInput("smallville.s09e15.hdtv.xvid-2hd.avi", "smallville", "9", "15", "Escape",
+                                 ""));
+        values.add(new TestInput("the.big.bang.theory.s03e18.720p.hdtv.x264-ctu.mkv",
+                                 "the big bang theory", "3", "18", "The Pants Alternative", "720p"));
+        values.add(new TestInput("castle.2009.s01e09.720p.hdtv.x264-ctu.mkv", "castle 2009", "1", "9",
+                                 "Little Girl Lost", "720p"));
         values.add(new TestInput("/TV/Dexter/S05E05 First Blood.mkv", "dexter", "5", "5", "First Blood", ""));
         values.add(new TestInput("/TV/Lost/Lost [2x07].mkv", "lost", "2", "7", "The Other 48 Days", ""));
-
-        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17", "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
-        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4", "Dicks", ""));
-        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "Continuum", "3", "7", "Waning Minutes", ""));
-        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "Elementary", "2", "23", "Art in the Blood", ""));
-        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19", "Meg Stinks!", ""));
-        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "Fargo", "1", "1", "The Crocodile's Dilemma", ""));
-        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "Girls", "3", "11", "I Saw You", ""));
-        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "Grimm", "3", "19", "Nobody Knows the Trubel I've Seen", ""));
-        values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "House Of Cards 2013", "1", "6", "Chapter 6", ""));
-        values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "Modern Family", "5", "12", "Under Pressure", ""));
+        values.add(new TestInput("American.Dad.S09E17.HDTV.x264-2HD.mp4", "american dad", "9", "17",
+                                 "The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith", ""));
+        values.add(new TestInput("Californication.S07E04.HDTV.x264-2HD.mp4", "californication", "7", "4",
+                                 "Dicks", ""));
+        values.add(new TestInput("Continuum.S03E07.HDTV.x264-2HD.mp4", "continuum", "3", "7",
+                                 "Waning Minutes", ""));
+        values.add(new TestInput("Elementary.S02E23.HDTV.x264-LOL.mp4", "elementary", "2", "23",
+                                 "Art in the Blood", ""));
+        values.add(new TestInput("Family.Guy.S12E19.HDTV.x264-2HD.mp4", "family guy", "12", "19",
+                                 "Meg Stinks!", ""));
+        values.add(new TestInput("Fargo.S01E01.HDTV.x264-2HD.mp4", "fargo", "1", "1",
+                                 "The Crocodile's Dilemma", ""));
+        values.add(new TestInput("Girls.S03E11.HDTV.x264-KILLERS.mp4", "girls", "3", "11", "I Saw You", ""));
+        values.add(new TestInput("Grimm.S03E19.HDTV.x264-LOL.mp4", "grimm", "3", "19",
+                                 "Nobody Knows the Trubel I've Seen", ""));
+        values.add(new TestInput("House.Of.Cards.2013.S01E06.HDTV.x264-EVOLVE.mp4", "house of cards 2013",
+                                 "1", "6", "Chapter 6", ""));
+        values.add(new TestInput("Modern.Family.S05E12.HDTV.x264-EXCELLENCE.mp4", "modern family", "5",
+                                 "12", "Under Pressure", ""));
         values.add(new TestInput("New.Girl.S03E23.HDTV.x264-LOL.mp4", "new girl", "3", "23", "Cruise", ""));
-        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "Nurse Jackie", "6", "4", "Jungle Love", ""));
-        values.add(new TestInput("Offspring - S05E01.mp4", "Offspring", "5", "1", "Back in the Game", ""));
-        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "Reign 2013", "1", "20", "Higher Ground", ""));
-        values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "Robot Chicken", "7", "4", "Rebel Appliance", ""));
-        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "Supernatural", "9", "21", "King of the Damned", ""));
-        values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "The Americans 2013", "2", "10", "Yousaf", ""));
-        values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "The Big Bang Theory", "7", "23", "The Gorilla Dissolution", ""));
-        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "The Good Wife", "5", "20", "The Deep Web", ""));
-        values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "The Walking Dead", "4", "16", "A", ""));
-        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "Veep", "3", "5", "Fishing", ""));
-        values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4", "Witches of East End", "1", "1", "Pilot", ""));
-        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "Warehouse 13", "5", "4", "Savage Seduction", ""));
-
-        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "The 100", "2", "8", "Spacewalker", "")); // issue #79
-
-        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "Firefly", "1", "1", "Serenity", ""));
-        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "Firefly", "1", "2", "The Train Job", ""));
-        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "Firefly", "1", "3", "Bushwhacked", ""));
-        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "Firefly", "1", "4", "Shindig", ""));
-        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "Firefly", "1", "5", "Safe", ""));
-        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "Firefly", "1", "6", "Our Mrs. Reynolds", ""));
-        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "Firefly", "1", "7", "Jaynestown", ""));
-        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "Firefly", "1", "8", "Out of Gas", ""));
-        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "Firefly", "1", "9", "Ariel", ""));
-        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "Firefly", "1", "10", "War Stories", ""));
-        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "Firefly", "1", "11", "Trash", ""));
-        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "Firefly", "1", "12", "The Message", ""));
-        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "Firefly", "1", "13", "Heart of Gold", ""));
-        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "Firefly", "1", "14", "Objects in Space", ""));
-
-        values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "Strike Back", "1", "1",
-                                 "Chris Ryan's Strike Back, Episode 1", "720p"));
-
-        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "Law and Order SVU", "17", "05", "Community Policing", ""));
-        values.add(new TestInput("ncis.1304.hdtv-lol", "NCIS", "13", "04", "Double Trouble", ""));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET", "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS", "marvels agents of shield", "3", "10", "Maveth", ""));
-        values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1", "Don Hoberman", "720p"));
-
-        values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "The Big Bang Theory", "10", "4", "The Cohabitation Experimentation", "720p"));
-        values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "Lucifer", "2", "3", "Sin-Eater", "720p"));
-        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv", "Marvels Agents of SHIELD", "4", "3", "Uprising", "1080p"));
-        values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "Supernatural", "11", "22", "We Happy Few", "1080p"));
-        values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "Supernatural", "11", "22", "We Happy Few", "720p"));
-        values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "Channel Zero", "1", "1", "You Have to Go Inside", "480p"));
-        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "NCIS", "14", "4", "Love Boat", "720p"));
+        values.add(new TestInput("Nurse.Jackie.S06E04.HDTV.x264-2HD.mp4", "nurse jackie", "6", "4",
+                                 "Jungle Love", ""));
+        values.add(new TestInput("Offspring - S05E01.mp4", "offspring", "5", "1", "Back in the Game", ""));
+        values.add(new TestInput("Reign.2013.S01E20.HDTV.x264-2HD.mp4", "reign 2013", "1", "20",
+                                 "Higher Ground", ""));
+        values.add(new TestInput("Robot.Chicken.S07E04.PROPER.HDTV.x264-W4F.mp4", "robot chicken", "7",
+                                 "4", "Rebel Appliance", ""));
+        values.add(new TestInput("Supernatural.S09E21.HDTV.x264-LOL.mp4", "supernatural", "9", "21",
+                                 "King of the Damned", ""));
+        values.add(new TestInput("The.Americans.2013.S02E10.HDTV.x264-LOL.mp4", "the americans 2013", "2",
+                                 "10", "Yousaf", ""));
+        values.add(new TestInput("The.Big.Bang.Theory.S07E23.HDTV.x264-LOL.mp4", "the big bang theory",
+                                 "7", "23", "The Gorilla Dissolution", ""));
+        values.add(new TestInput("The.Good.Wife.S05E20.HDTV.x264-LOL.mp4", "the good wife", "5", "20",
+                                 "The Deep Web", ""));
+        values.add(new TestInput("The.Walking.Dead.S04E16.PROPER.HDTV.x264-2HD.mp4", "the walking dead",
+                                 "4", "16", "A", ""));
+        values.add(new TestInput("Veep.S03E05.HDTV.x264-KILLERS.mp4", "veep", "3", "5", "Fishing", ""));
+        values.add(new TestInput("Witches.of.East.End.S01E01.PROPER.HDTV.x264-2HD.mp4",
+                                 "witches of east end", "1", "1", "Pilot", ""));
+        values.add(new TestInput("Warehouse.13.S05E04.HDTV.x264-2HD.mp4", "warehouse 13", "5", "4",
+                                 "Savage Seduction", ""));
+        values.add(new TestInput("the.100.208.hdtv-lol.mp4", "the 100", "2", "8", "Spacewalker", ""));
+        values.add(new TestInput("firefly.1x01.hdtv-lol.mp4", "firefly", "1", "1", "Serenity", ""));
+        values.add(new TestInput("firefly.1x02.hdtv-lol.mp4", "firefly", "1", "2", "The Train Job", ""));
+        values.add(new TestInput("firefly.1x03.hdtv-lol.mp4", "firefly", "1", "3", "Bushwhacked", ""));
+        values.add(new TestInput("firefly.1x04.hdtv-lol.mp4", "firefly", "1", "4", "Shindig", ""));
+        values.add(new TestInput("firefly.1x05.hdtv-lol.mp4", "firefly", "1", "5", "Safe", ""));
+        values.add(new TestInput("firefly.1x06.hdtv-lol.mp4", "firefly", "1", "6", "Our Mrs. Reynolds", ""));
+        values.add(new TestInput("firefly.1x07.hdtv-lol.mp4", "firefly", "1", "7", "Jaynestown", ""));
+        values.add(new TestInput("firefly.1x08.hdtv-lol.mp4", "firefly", "1", "8", "Out of Gas", ""));
+        values.add(new TestInput("firefly.1x09.hdtv-lol.mp4", "firefly", "1", "9", "Ariel", ""));
+        values.add(new TestInput("firefly.1x10.hdtv-lol.mp4", "firefly", "1", "10", "War Stories", ""));
+        values.add(new TestInput("firefly.1x11.hdtv-lol.mp4", "firefly", "1", "11", "Trash", ""));
+        values.add(new TestInput("firefly.1x12.hdtv-lol.mp4", "firefly", "1", "12", "The Message", ""));
+        values.add(new TestInput("firefly.1x13.hdtv-lol.mp4", "firefly", "1", "13", "Heart of Gold", ""));
+        values.add(new TestInput("firefly.1x14.hdtv-lol.mp4", "firefly", "1", "14", "Objects in Space", ""));
+        values.add(new TestInput("Strike.Back.S01E01.Mini.720p.HDTV.DD5.1.x264.mkv", "strike back", "1",
+                                 "1", "Chris Ryan's Strike Back, Episode 1", "720p"));
+        values.add(new TestInput("law.and.order.svu.1705.hdtv-lol", "law and order svu", "17", "05",
+                                 "Community Policing", ""));
+        values.add(new TestInput("ncis.1304.hdtv-lol", "ncis", "13", "04", "Double Trouble", ""));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E03.HDTV.x264-FLEET",
+                                 "marvels agents of shield", "3", "3", "A Wanted (Inhu)man", ""));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S03E10.HDTV.x264-KILLERS",
+                                 "marvels agents of shield", "3", "10", "Maveth", ""));
+        values.add(new TestInput("Nip.Tuck.S06E01.720p.HDTV.X264-DIMENSION.mkv", "nip tuck", "6", "1",
+                                 "Don Hoberman", "720p"));
+        values.add(new TestInput("The.Big.Bang.Theory.S10E04.720p.HDTV.X264-DIMENSION[ettv].mkv",
+                                 "the big bang theory", "10", "4", "The Cohabitation Experimentation", "720p"));
+        values.add(new TestInput("Lucifer.S02E03.720p.HDTV.X264-DIMENSION[ettv].mkv", "lucifer", "2", "3",
+                                 "Sin-Eater", "720p"));
+        values.add(new TestInput("Marvels.Agents.of.S.H.I.E.L.D.S04E03.1080p.HDTV.x264-KILLERS[ettv].mkv",
+                                 "marvels agents of shield", "4", "3", "Uprising", "1080p"));
+        values.add(new TestInput("Supernatural.S11E22.1080p.HDTV.X264-DIMENSION[ettv].mkv", "supernatural",
+                                 "11", "22", "We Happy Few", "1080p"));
+        values.add(new TestInput("Supernatural.S11E22.HDTV.X264-DIMENSION.720p.[ettv].mkv", "supernatural",
+                                 "11", "22", "We Happy Few", "720p"));
+        values.add(new TestInput("Channel.Zero.S01E01.480p.HDTV.X264-DIMENSION[ettv].mkv", "channel zero",
+                                 "1", "1", "You Have to Go Inside", "480p"));
+        values.add(new TestInput("NCIS.S14E04.720p.HDTV.X264-DIMENSION[ettv].mkv", "ncis", "14", "4",
+                                 "Love Boat", "720p"));
     }
 
     @Test
@@ -133,7 +173,8 @@ public class TheTVDBProviderTest {
                     ShowStore.getShow(showName, new ShowInformationListener() {
                         @Override
                         public void downloaded(Show show) {
-                            future.complete(show.getSeason(fileEpisode.getSeasonNumber()).getTitle(fileEpisode.getEpisodeNumber()));
+                            future.complete(show.getSeason(fileEpisode.getSeasonNumber())
+                                            .getTitle(fileEpisode.getEpisodeNumber()));
                         }
 
                         @Override

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.mock;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import org.tvrenamer.controller.ShowInformationListener;
 
@@ -29,7 +28,10 @@ public class FileEpisodeTest {
     @Before
     public void setUp() throws Exception {
         testFiles = new ArrayList<>();
-        prefs = Mockito.mock(UserPreferences.class);
+        prefs = UserPreferences.getInstance();
+        prefs.setRenameReplacementString("%S [%sx%e] %t");
+        prefs.setMoveEnabled(false);
+        prefs.setRenameEnabled(true);
         mockListener = mock(ShowInformationListener.class);
     }
 
@@ -53,8 +55,6 @@ public class FileEpisodeTest {
         season5.addEpisode(episodeNum, title, LocalDate.now());
         show.setSeason(seasonNum, season5);
         ShowStore.addShow(showName, show);
-
-        Mockito.when(prefs.getRenameReplacementString()).thenReturn("%S [%sx%e] %t");
 
         FileEpisode episode = new FileEpisode(showName, seasonNum, episodeNum, resolution, file);
         episode.setStatus(EpisodeStatus.DOWNLOADED);


### PR DESCRIPTION
This push reworks the jUnit tests in several ways.  The individual commits are well documented and commented, so please see them for details.  In general, though, this changes things so that:
(1) The file TVRenamerTest.java tests parsing of many different filenames, but does not access the internet or rely on external data.  It only has the test data that it requires (so, no file episodes), and line length is kept reasonable.
(2) The file FileEpisodeTest.java no longer tries to "mock" UserPreferences, but instead gets a real instance, modifies it, but doesn't save it out.  This allows the test to pass no matter what the user's personal preferences are (which was not true before)
(3) The file TheTVDBProviderTest.java tests downloading data from thetvdb.com.  It is currently active for a single, well-selected test that is unlikely to fail for any invalid reason.  It also contains a much larger test, which previously was part of TVRenamerTest, that tests a bunch of filenames, in a multi-threaded way.  But this code is currently not made a "Test", and is not run by "ant test".  I don't think this download should be part of a build.
(4) Logging "info" messages that cluttered up the test output have been reduced to level "fine".