### PR TITLE
Use java.nio for files

### DIFF
--- a/src/main/org/tvrenamer/controller/AddEpisodeListener.java
+++ b/src/main/org/tvrenamer/controller/AddEpisodeListener.java
@@ -1,0 +1,9 @@
+package org.tvrenamer.controller;
+
+import org.tvrenamer.model.FileEpisode;
+
+import java.util.Queue;
+
+public interface AddEpisodeListener {
+    public void addEpisodes(Queue<FileEpisode> episodes);
+}

--- a/src/main/org/tvrenamer/controller/FileMover.java
+++ b/src/main/org/tvrenamer/controller/FileMover.java
@@ -11,14 +11,18 @@ import org.tvrenamer.model.UserPreferences;
 import org.tvrenamer.view.FileCopyMonitor;
 import org.tvrenamer.view.UIStarter;
 
-import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
 import java.util.concurrent.Callable;
 import java.util.logging.Logger;
 
 public class FileMover implements Callable<Boolean> {
     private static Logger logger = Logger.getLogger(FileMover.class.getName());
 
-    private final File destFile;
+    private final Path destPath;
 
     private final TableItem item;
 
@@ -28,64 +32,83 @@ public class FileMover implements Callable<Boolean> {
 
     private final Display display;
 
-    public FileMover(Display display, FileEpisode src, File destFile, TableItem item, Label progressLabel) {
+    public FileMover(Display display, FileEpisode src, Path destPath, TableItem item, Label progressLabel) {
         this.display = display;
         this.episode = src;
-        this.destFile = destFile;
+        this.destPath = destPath;
         this.item = item;
         this.progressLabel = progressLabel;
     }
 
+    private void cleanUpLabel() {
+        // We only use the progressLabel if we're doing the "copy-and-delete" method.  But we
+        // have created it beforehand, not knowing which method we'd be using.  So, regardless
+        // of how we tried to move the file, and regardless of whether it succeeded or not,
+        // we need to get rid of the label.
+        if (!display.isDisposed()) {
+            display.asyncExec(new Runnable() {
+                    @Override
+                    public void run() {
+                        if (progressLabel.isDisposed()) {
+                            return;
+                        }
+                        progressLabel.dispose();
+                    }
+                });
+        }
+    }
+
     @Override
     public Boolean call() {
-        File srcFile = this.episode.getFile();
-        if (destFile.getParentFile().exists() || destFile.getParentFile().mkdirs()) {
+        Path srcPath = episode.getPath();
+        Path destDir = destPath.getParent();
+        if (Files.notExists(destDir)) {
+            FileUtilities.mkdirs(destDir);
+        }
+        if (Files.exists(destDir) && Files.isDirectory(destDir)) {
             UIStarter.setTableItemStatus(display, item, FileMoveIcon.RENAMING);
             boolean succeeded = false;
-            if (FileUtilities.areSameDisk(srcFile, destFile)) {
-                succeeded = srcFile.renameTo(destFile);
-            }
-            if (succeeded) {
-                UIStarter.setTableItemStatus(display, item, FileMoveIcon.SUCCESS);
-                logger.info("Moved " + srcFile.getAbsolutePath() + " to " + destFile.getAbsolutePath());
-                episode.setFile(destFile);
-                this.updateFileModifiedDate(destFile);
-                return true;
-            } else {
-                FileCopyMonitor monitor = new FileCopyMonitor(progressLabel, srcFile.length());
-                succeeded = FileUtilities.moveFile(srcFile, destFile, monitor, true);
-                if (!display.isDisposed()) {
-                    display.asyncExec(new Runnable() {
-                        @Override
-                        public void run() {
-                            if (progressLabel.isDisposed()) {
-                                return;
-                            }
-                            progressLabel.setText("");
-                        }
-                    });
+            try {
+                if (FileUtilities.areSameDisk(srcPath, destDir)) {
+                    Path actualDest = Files.move(srcPath, destPath);
+                    succeeded = Files.isSameFile(destPath, actualDest);
+                }
+                if (!succeeded) {
+                    long size = Files.size(srcPath);
+                    FileCopyMonitor monitor = new FileCopyMonitor(progressLabel, size);
+                    succeeded = FileUtilities.moveFile(srcPath, destPath, monitor);
                 }
                 if (succeeded) {
-                    logger.info("Moved " + srcFile.getAbsolutePath() + " to " + destFile.getAbsolutePath());
-                    this.updateFileModifiedDate(destFile);
-                    episode.setFile(destFile);
+                    updateFileModifiedDate(destPath);
+                    episode.setPath(destPath);
+                    logger.info("Moved " + srcPath.toAbsolutePath() + " to " + destPath.toAbsolutePath());
                     UIStarter.setTableItemStatus(display, item, FileMoveIcon.SUCCESS);
                 } else {
-                    logger.severe("Unable to move " + srcFile.getAbsolutePath() + " to " + destFile.getAbsolutePath());
+                    logger.severe("Unable to move " + srcPath.toAbsolutePath() + " to "
+                                  + destPath.toAbsolutePath());
                     UIStarter.setTableItemStatus(display, item, FileMoveIcon.FAIL);
                 }
-                return succeeded;
+                cleanUpLabel();
+            } catch (IOException ioe) {
+                logger.warning("IO Exception");
             }
+            return succeeded;
+        } else {
+            logger.severe("Unable to move file to " + destPath.toAbsolutePath().toString());
         }
         return false;
     }
 
-    private void updateFileModifiedDate(File file) {
+    private void updateFileModifiedDate(Path path)
+        throws IOException
+    {
+        FileTime timestamp = FileTime.from(Instant.now());
+
         // update the modified time on the file, the parent, and the grandparent
-        file.setLastModified(System.currentTimeMillis());
+        Files.setLastModifiedTime(path, timestamp);
         if (UserPreferences.getInstance().isMoveEnabled()) {
-            file.getParentFile().setLastModified(System.currentTimeMillis());
-            file.getParentFile().getParentFile().setLastModified(System.currentTimeMillis());
+            Files.setLastModifiedTime(path.getParent(), timestamp);
+            Files.setLastModifiedTime(path.getParent().getParent(), timestamp);
         }
     }
 }

--- a/src/main/org/tvrenamer/model/EpisodeDb.java
+++ b/src/main/org/tvrenamer/model/EpisodeDb.java
@@ -1,0 +1,92 @@
+package org.tvrenamer.model;
+
+import org.tvrenamer.controller.TVRenamer;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+public class EpisodeDb {
+
+    private static Logger logger = Logger.getLogger(EpisodeDb.class.getName());
+
+    private final Map<String, FileEpisode> episodes = new ConcurrentHashMap<>(1000);
+    private final UserPreferences prefs = UserPreferences.getInstance();
+
+    public void put(String key, FileEpisode value) {
+        if (value == null) {
+            logger.info("cannot put null value into EpisodeDb!!!");
+            return;
+        }
+
+        if (key == null) {
+            logger.warning("cannot put null key into EpisodeDb!!!");
+            return;
+        }
+
+        episodes.put(key, value);
+    }
+
+    private FileEpisode add(final String pathname) {
+        final FileEpisode episode = TVRenamer.parseFilename(pathname);
+        if (episode == null) {
+            logger.severe("Couldn't parse file: " + pathname);
+        } else {
+            put(pathname, episode);
+        }
+        return episode;
+    }
+
+    public FileEpisode remove(String key) {
+        return episodes.remove(key);
+    }
+
+    public boolean remove(String key, FileEpisode value) {
+        return episodes.remove(key, value);
+    }
+
+    public boolean replaceKey(String oldKey, FileEpisode ep, String newKey) {
+        if (ep == null) {
+            throw new IllegalStateException("cannot have null value in EpisodeDb!!!");
+        }
+
+        if ((oldKey == null) || (oldKey.length() == 0)) {
+            throw new IllegalStateException("cannot have null key in EpisodeDb!!!");
+        }
+
+        boolean removed = episodes.remove(oldKey, ep);
+        if (!removed) {
+            throw new IllegalStateException("unrecoverable episode DB corruption");
+        }
+
+        FileEpisode oldValue = episodes.put(newKey, ep);
+        // The value returned is the *old* value for the key.  We expect it to be
+        // null.  If it isn't, that means the new key was already mapped to an
+        // episode.  In theory, this could legitimately happen if we rename A to B
+        // and B to A, or any longer such cycle.  But that seems extremely unlikely
+        // with this particular program, so we'll just warn and do nothing about it.
+        if (oldValue != null) {
+            logger.warning("removing episode from db due to new episode at that location: "
+                           + oldValue);
+            return false;
+        }
+        return true;
+    }
+
+    public FileEpisode get(String key) {
+        return episodes.get(key);
+    }
+
+    private boolean containsKey(String key) {
+        return episodes.containsKey(key);
+    }
+
+    private void clear() {
+        episodes.clear();
+    }
+
+    @Override
+    public String toString() {
+        return "{EpisodeDb with " + episodes.size() + " files}";
+    }
+}

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -3,6 +3,7 @@ package org.tvrenamer.model;
 import org.tvrenamer.controller.util.StringUtils;
 
 import java.io.File;
+import java.nio.file.Path;
 import java.text.DecimalFormat;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
@@ -80,6 +81,14 @@ public class FileEpisode {
 
     public void setFile(File f) {
         file = f;
+    }
+
+    public Path getPath() {
+        return file.toPath();
+    }
+
+    public void setPath(Path p) {
+        file = p.toFile();
     }
 
     public EpisodeStatus getStatus() {

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -835,7 +835,8 @@ public class UIStarter implements Observer {
                     editor.grabHorizontal = true;
                     editor.setEditor(progressLabel, item, STATUS_COLUMN);
 
-                    Callable<Boolean> moveCallable = new FileMover(display, episode, newFile, item, progressLabel);
+                    Callable<Boolean> moveCallable = new FileMover(display, episode, newFile.toPath(),
+                                                                   item, progressLabel);
                     futures.add(executor.submit(moveCallable));
                     item.setChecked(false);
                 }

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -49,6 +49,7 @@ import org.tvrenamer.controller.ShowInformationListener;
 import org.tvrenamer.controller.TVRenamer;
 import org.tvrenamer.controller.UpdateChecker;
 import org.tvrenamer.controller.UpdateCompleteHandler;
+import org.tvrenamer.model.EpisodeDb;
 import org.tvrenamer.model.EpisodeStatus;
 import org.tvrenamer.model.FileEpisode;
 import org.tvrenamer.model.FileMoveIcon;
@@ -69,11 +70,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.Collator;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Queue;
@@ -114,7 +113,7 @@ public class UIStarter implements Observer {
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
 
     private UserPreferences prefs;
-    private Map<String, FileEpisode> episodeMap = new HashMap<>();
+    private EpisodeDb episodeMap = new EpisodeDb();
 
     // Static initalisation block
     static {

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -9,9 +9,12 @@ import org.junit.Before;
 import org.junit.Test;
 
 import org.tvrenamer.controller.ShowInformationListener;
+import org.tvrenamer.controller.util.FileUtilities;
 
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +23,10 @@ import java.util.logging.Logger;
 public class FileEpisodeTest {
     private static Logger logger = Logger.getLogger(FileEpisodeTest.class.getName());
 
-    private List<File> testFiles;
+    private static final String TEMP_DIR_NAME = System.getProperty("java.io.tmpdir");
+    private static final Path TEMP_DIR = Paths.get(TEMP_DIR_NAME);
+
+    private List<Path> testFiles;
 
     private UserPreferences prefs;
     private ShowInformationListener mockListener;
@@ -41,14 +47,15 @@ public class FileEpisodeTest {
      */
     @Test
     public void testGetNewFilenameSpecialRegexChars() throws Exception {
+        String filename = "the.simpsons.5.10.avi";
+        Path path = TEMP_DIR.resolve(filename);
+        createFile(path);
+
         String showName = "The Simpsons";
         String title = "$pringfield";
         int seasonNum = 5;
         int episodeNum = 10;
         String resolution = "";
-        File file = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator")
-                + "the.simpsons.5.10.avi");
-        createFile(file);
 
         Show show = new Show("1", showName, "http://thetvdb.com/?tab=series&id=71663");
         Season season5 = new Season(seasonNum);
@@ -56,7 +63,7 @@ public class FileEpisodeTest {
         show.setSeason(seasonNum, season5);
         ShowStore.addShow(showName, show);
 
-        FileEpisode episode = new FileEpisode(showName, seasonNum, episodeNum, resolution, file);
+        FileEpisode episode = new FileEpisode(showName, seasonNum, episodeNum, resolution, path);
         episode.setStatus(EpisodeStatus.DOWNLOADED);
 
         String newFilename = episode.getNewFilename();
@@ -70,14 +77,15 @@ public class FileEpisodeTest {
      */
     @Test
     public void testColon() throws Exception {
+        String filename = "steven.segal.lawman.1.01.avi";
+        Path path = TEMP_DIR.resolve(filename);
+        createFile(path);
+
         String showName = "Steven Seagal: Lawman";
         String title = "The Way of the Gun";
         int seasonNum = 1;
         int episodeNum = 1;
         String resolution = "";
-        File file = new File(System.getProperty("java.io.tmpdir") + System.getProperty("file.separator")
-                + "steven.segal.lawman.1.01.avi");
-        createFile(file);
 
         Show show = new Show("1", showName, "http://thetvdb.com/?tab=series&id=126841&lid=7");
         Season season1 = new Season(seasonNum);
@@ -85,7 +93,7 @@ public class FileEpisodeTest {
         show.setSeason(seasonNum, season1);
         ShowStore.addShow(showName, show);
 
-        FileEpisode fileEpisode = new FileEpisode(showName, seasonNum, episodeNum, resolution, file);
+        FileEpisode fileEpisode = new FileEpisode(showName, seasonNum, episodeNum, resolution, path);
         fileEpisode.setStatus(EpisodeStatus.RENAMED);
 
         String newFilename = fileEpisode.getNewFilename();
@@ -96,16 +104,16 @@ public class FileEpisodeTest {
     /**
      * Helper method to physically create the file and add to file list for later deletion.
      */
-    private void createFile(File file) throws IOException {
-        file.createNewFile();
-        testFiles.add(file);
+    private void createFile(Path path) throws IOException {
+        Files.createFile(path);
+        testFiles.add(path);
     }
 
     @After
     public void teardown() throws Exception {
-        for (File file : testFiles) {
-            logger.info("Deleting " + file);
-            file.delete();
+        for (Path path : testFiles) {
+            logger.info("Deleting " + path);
+            FileUtilities.deleteFile(path);
         }
     }
 }


### PR DESCRIPTION
The java.nio.file.Path class is a mostly-straightforward replacement for java.io.File.  I pretty much just replaced all of the File functionality with equivalent Path functionality.

I did it in incremental commits, including a couple of things that were intended to show how the change is progressing.

One change included here that was not _directly_ a result of switching to Paths is that UIStarter no longer loads its own files.  It relies on the EpisodeDb class for that, using a subscribe-and-publish model.

This change also makes it much less likely that #148 will not occur, because FileUtilities.moveFile now tries not to overwrite an existing file.

The individual commits are well-documented, so please see them for more details.