### PR TITLE
a few very small changes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -248,7 +248,7 @@
       <classpath refid="classpath.test" />
 
       <batchtest>
-        <fileset dir="${src.test}" />
+        <fileset dir="${src.test}" includes="**/*Test.java" />
       </batchtest>
     </junit>
   </target>

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -49,6 +49,10 @@ public class Show implements Comparable<Show> {
         return seasons.get(sNum);
     }
 
+    public int getSeasonCount() {
+        return seasons.size();
+    }
+
     @Override
     public String toString() {
         return "Show [" + name + ", id=" + id + ", url=" + url + ", " + seasons.size() + " seasons]";

--- a/src/main/org/tvrenamer/view/ProgressBarUpdater.java
+++ b/src/main/org/tvrenamer/view/ProgressBarUpdater.java
@@ -17,13 +17,13 @@ public class ProgressBarUpdater implements Runnable {
 
     private final ProgressProxy proxy;
 
-    public ProgressBarUpdater(ProgressProxy proxy, int total, Queue<Future<Boolean>> futures,
-        UpdateCompleteHandler updateComplete)
+    public ProgressBarUpdater(ProgressProxy proxy, Queue<Future<Boolean>> futures,
+                              UpdateCompleteHandler updateComplete)
     {
         this.proxy = proxy;
-        this.totalNumFiles = total;
+        totalNumFiles = futures.size();
         this.futures = futures;
-        this.updateCompleteHandler = updateComplete;
+        updateCompleteHandler = updateComplete;
     }
 
     @Override
@@ -39,7 +39,8 @@ public class ProgressBarUpdater implements Runnable {
 
             try {
                 Future<Boolean> future = futures.remove();
-                logger.info("future returned: " + future.get());
+                Boolean success = future.get();
+                logger.info("future returned: " + success);
             } catch (InterruptedException | ExecutionException e) {
                 e.printStackTrace();
             }

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -705,7 +705,6 @@ public class UIStarter implements Observer,  AddEpisodeListener {
 
     private void renameFiles() {
         final Queue<Future<Boolean>> futures = new LinkedList<>();
-        int count = 0;
 
         for (final TableItem item : resultsTable.getItems()) {
             if (item.getChecked()) {
@@ -716,13 +715,12 @@ public class UIStarter implements Observer,  AddEpisodeListener {
                     continue;
                 }
 
-                count++;
                 final Path currentFile = Paths.get(fileName);
                 String newName = item.getText(NEW_FILENAME_COLUMN);
 
                 Path newFile = null;
 
-                if (prefs != null && prefs.isMoveEnabled()) {
+                if (prefs.isMoveEnabled()) {
                     // If move is enabled, let the File constructor parse the path
                     newFile = Paths.get(newName);
                 } else {
@@ -787,7 +785,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
                         }
                     });
                 }
-            }, count, futures, new UpdateCompleteHandler() {
+            }, futures, new UpdateCompleteHandler() {
                 @Override
                 public void onUpdateComplete() {
                     display.asyncExec(new Runnable() {


### PR DESCRIPTION
When UIStarter creates the thread to update the progress bar that shows how many files have been moved, it passed in a count.  That count was the total of all the files that were selected (checked) in the UI.  But not every file that is checked will actually be moved.  There are several things we don't detect until the "Move Files" button is actually pressed, that could prevent it from being moved.

I don't know, maybe this behavior was intentional.  Maybe the progress bar was supposed to consider those files which are not being moved, as "done".  But I think it makes a lot more sense for the progress bar to show only progress on files that are actually being moved.  As a side benefit, if we do it that way, we don't need to explicitly keep count.  The count is just the number of "moves" we pass in.

Also, the code in the middle of renameFiles did a null check on the variable prefs.  I don't think it's possible for the variable to be null.  If it somehow is, then probably the right behavior is to get an unhandled null pointer exception.  It doesn't make sense to just treat it as if move is disabled.  So, eliminate the check.

In build.xml, specify which classes are "test" files, so that we can potentially have other helper classes in the directory that jUnit doesn't try to "run".

Add getSeasonCount() to Show.java for future usage.