### PR TITLE
enhance distinction between downloading shows and downloading listings

### DIFF
--- a/src/main/org/tvrenamer/controller/ListingsLookup.java
+++ b/src/main/org/tvrenamer/controller/ListingsLookup.java
@@ -1,0 +1,137 @@
+package org.tvrenamer.controller;
+
+import org.tvrenamer.model.Show;
+import org.tvrenamer.model.TVRenamerIOException;
+
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class ListingsLookup {
+
+    private static Logger logger = Logger.getLogger(ListingsLookup.class.getName());
+
+    private static class ListingsRegistrations {
+        private final List<ShowListingsListener> listeners;
+
+        public ListingsRegistrations() {
+            this.listeners = new LinkedList<>();
+        }
+
+        public void addListener(ShowListingsListener listener) {
+            this.listeners.add(listener);
+        }
+
+        public List<ShowListingsListener> getListeners() {
+            return Collections.unmodifiableList(listeners);
+        }
+    }
+
+    private static final Map<String, ListingsRegistrations> listenersMap = new ConcurrentHashMap<>(100);
+
+    private static final ExecutorService THREAD_POOL
+        = Executors.newCachedThreadPool(new ThreadFactory() {
+                // We want the lookup thread to run at the minimum priority, to try to
+                // keep the UI as responsive as possible.
+                @Override
+                public Thread newThread(Runnable r) {
+                    Thread t = new Thread(r);
+                    t.setPriority(Thread.MIN_PRIORITY);
+                    t.setDaemon(true);
+                    return t;
+                }
+            });
+
+    private static void notifyListeners(Show show) {
+        ListingsRegistrations registrations = listenersMap.get(show.getId());
+
+        if (registrations != null) {
+            for (ShowListingsListener listener : registrations.getListeners()) {
+                if (show.hasSeasons()) {
+                    listener.downloadListingsComplete(show);
+                } else {
+                    listener.downloadListingsFailed(show);
+                }
+            }
+        }
+    }
+
+    private static void downloadListings(final Show show) {
+        Callable<Boolean> showFetcher = new Callable<Boolean>() {
+                @Override
+                public Boolean call() throws InterruptedException {
+                    try {
+                        TheTVDBProvider.getShowListing(show);
+                        notifyListeners(show);
+                        return true;
+                    } catch (TVRenamerIOException e) {
+                        notifyListeners(show);
+                        return false;
+                    } catch (Exception e) {
+                        // Because this is running in a separate thread, an uncaught
+                        // exception does not get caught by the main thread, and
+                        // prevents this thread from dying.  Try to make sure that the
+                        // thread dies, one way or another.
+                        logger.log(Level.WARNING, "generic exception doing getListings for "
+                                   + show, e);
+                        notifyListeners(show);
+                        return false;
+                    }
+                }
+            };
+        THREAD_POOL.submit(showFetcher);
+    }
+
+    /**
+     * <p>
+     * Download the show details if required, otherwise notify listener.
+     * </p>
+     * <ul>
+     * <li>if we already have the show listings (the Show has season info) then just  call the method on the listener</li>
+     * <li>if we don't have the listings, but are in the process of processing them (exists in listenersMap) then
+     * add the listener to the registration</li>
+     * <li>if we don't have the listings and aren't processing, then create the
+     registration, add the listener and kick off
+     * the download</li>
+     * </ul>
+     *
+     * @param show
+     *            the Show object representing the show
+     * @param listener
+     *            the listener to notify or register
+     */
+    public static void getListings(final Show show, ShowListingsListener listener) {
+        String key = show.getId();
+        synchronized (listenersMap) {
+            ListingsRegistrations registrations = listenersMap.get(key);
+            if (registrations == null) {
+                registrations = new ListingsRegistrations();
+                listenersMap.put(key, registrations);
+            }
+            registrations.addListener(listener);
+        }
+
+        if (show.hasSeasons()) {
+            notifyListeners(show);
+            return;
+        }
+
+        downloadListings(show);
+    }
+
+    public static void cleanUp() {
+        THREAD_POOL.shutdownNow();
+    }
+
+    public static void clear() {
+        listenersMap.clear();
+    }
+}

--- a/src/main/org/tvrenamer/controller/ShowListingsListener.java
+++ b/src/main/org/tvrenamer/controller/ShowListingsListener.java
@@ -1,0 +1,9 @@
+package org.tvrenamer.controller;
+
+import org.tvrenamer.model.Show;
+
+public interface ShowListingsListener {
+    void downloadListingsComplete(Show show);
+
+    void downloadListingsFailed(Show show);
+}

--- a/src/main/org/tvrenamer/model/EpisodeStatus.java
+++ b/src/main/org/tvrenamer/model/EpisodeStatus.java
@@ -1,5 +1,5 @@
 package org.tvrenamer.model;
 
 public enum EpisodeStatus {
-    UNPARSED, ADDED, GOT_LISTINGS, RENAMED, BROKEN;
+    UNPARSED, ADDED, GOT_SHOW, GOT_LISTINGS, RENAMED, BROKEN;
 }

--- a/src/main/org/tvrenamer/model/EpisodeStatus.java
+++ b/src/main/org/tvrenamer/model/EpisodeStatus.java
@@ -1,5 +1,5 @@
 package org.tvrenamer.model;
 
 public enum EpisodeStatus {
-    UNPARSED, ADDED, DOWNLOADED, RENAMED, BROKEN;
+    UNPARSED, ADDED, GOT_LISTINGS, RENAMED, BROKEN;
 }

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -280,7 +280,7 @@ public class FileEpisode {
             case ADDED: {
                 return ADDED_PLACEHOLDER_FILENAME;
             }
-            case DOWNLOADED:
+            case GOT_LISTINGS:
             case RENAMED: {
                 String currentFilename = path.getFileName().toString();
                 String newFilename = getRenamedFilename();

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -271,6 +271,13 @@ public class FileEpisode {
         return baseForRename + filenameSuffix;
     }
 
+    private String getShowNamePlaceholder() {
+        Show show = ShowStore.getShow(queryString);
+        String showName = show.getName();
+
+        return "<" + showName + ">";
+    }
+
     /**
      * @return the new full file path (for table display) using {@link #getRenamedFilename()} and
      *          the destination directory
@@ -279,6 +286,9 @@ public class FileEpisode {
         switch (status) {
             case ADDED: {
                 return ADDED_PLACEHOLDER_FILENAME;
+            }
+            case GOT_SHOW: {
+                return getShowNamePlaceholder();
             }
             case GOT_LISTINGS:
             case RENAMED: {

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -271,36 +271,42 @@ public class FileEpisode {
         return baseForRename + filenameSuffix;
     }
 
-    public String getNewFilename() {
+    /**
+     * @return the new full file path (for table display) using {@link #getRenamedFilename()} and
+     *          the destination directory
+     */
+    public String getReplacementText() {
         switch (status) {
             case ADDED: {
                 return ADDED_PLACEHOLDER_FILENAME;
             }
             case DOWNLOADED:
             case RENAMED: {
-                if (!userPrefs.isRenameEnabled()) {
-                    return path.getFileName().toString();
+                String currentFilename = path.getFileName().toString();
+                String newFilename = getRenamedFilename();
+                String destDirectoryName = getDestinationDirectoryName();
+
+                if (userPrefs.isMoveEnabled()) {
+                    if (userPrefs.isRenameEnabled()) {
+                        return  destDirectoryName + FILE_SEPARATOR_STRING + newFilename;
+                    } else {
+                        return  destDirectoryName + FILE_SEPARATOR_STRING + currentFilename;
+                    }
+                } else {
+                    if (userPrefs.isRenameEnabled()) {
+                        return newFilename;
+                    } else {
+                        // This setting doesn't make any sense, but we haven't bothered to
+                        // disallow it yet.
+                        return currentFilename;
+                    }
                 }
-                return getRenamedFilename();
             }
             case UNPARSED:
             case BROKEN:
             default:
                 return BROKEN_PLACEHOLDER_FILENAME;
         }
-    }
-
-    /**
-     * @return the new full file path (for table display) using {@link #getNewFilename()} and
-     *          the destination directory
-     */
-    public String getNewFilePath() {
-        String filename = getNewFilename();
-
-        if (userPrefs.isMoveEnabled()) {
-            return getDestinationDirectoryName() + FILE_SEPARATOR_STRING + filename;
-        }
-        return filename;
     }
 
     @Override

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -49,6 +49,10 @@ public class Show implements Comparable<Show> {
         return seasons.get(sNum);
     }
 
+    public boolean hasSeasons() {
+        return (seasons.size() > 0);
+    }
+
     public int getSeasonCount() {
         return seasons.size();
     }

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -648,7 +648,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
     }
 
     private void tableItemDownloaded(TableItem item, FileEpisode episode) {
-        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
+        episode.setStatus(EpisodeStatus.GOT_SHOW);
         display.asyncExec(new Runnable() {
                 @Override
                 public void run() {

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -665,7 +665,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
                                 @Override
                                 public void run() {
                                     if ( tableContainsTableItem(item) ) {
-                                        item.setText(NEW_FILENAME_COLUMN, episode.getNewFilePath());
+                                        item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
                                         item.setImage(STATUS_COLUMN, FileMoveIcon.ADDED.icon);
                                     }
                                 }
@@ -827,7 +827,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
             // to a list of banned keywords
             item.setChecked(!isNameIgnored(newFilename));
 
-            newFilename = episode.getNewFilename();
+            newFilename = episode.getReplacementText();
         } catch (NotFoundException e) {
             newFilename = e.getMessage();
             item.setChecked(false);
@@ -920,7 +920,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
             String newFileName = episode.getFilepath();
             episodeMap.put(newFileName, episode);
             item.setText(CURRENT_FILE_COLUMN, newFileName);
-            item.setText(NEW_FILENAME_COLUMN, episode.getNewFilePath());
+            item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
         }
     }
 

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -660,7 +660,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
             ShowStore.getShow(showName, new ShowInformationListener() {
                     @Override
                     public void downloaded(Show show) {
-                        episode.setStatus(EpisodeStatus.DOWNLOADED);
+                        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
                         display.asyncExec(new Runnable() {
                                 @Override
                                 public void run() {
@@ -711,7 +711,7 @@ public class UIStarter implements Observer,  AddEpisodeListener {
                 String fileName = item.getText(CURRENT_FILE_COLUMN);
                 final FileEpisode episode = episodeMap.get(fileName);
                 // Skip files not successfully downloaded
-                if (episode.getStatus() != EpisodeStatus.DOWNLOADED) {
+                if (episode.getStatus() != EpisodeStatus.GOT_LISTINGS) {
                     continue;
                 }
 

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -647,6 +647,33 @@ public class UIStarter implements Observer,  AddEpisodeListener {
         launch();
     }
 
+    private void tableItemDownloaded(TableItem item, FileEpisode episode) {
+        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
+        display.asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    if ( tableContainsTableItem(item) ) {
+                        item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
+                        item.setImage(STATUS_COLUMN, FileMoveIcon.ADDED.icon);
+                    }
+                }
+            });
+    }
+
+    private void tableItemFailed(TableItem item, FileEpisode episode) {
+        episode.setStatus(EpisodeStatus.BROKEN);
+        display.asyncExec(new Runnable() {
+                @Override
+                public void run() {
+                    if ( tableContainsTableItem(item) ) {
+                        item.setText(NEW_FILENAME_COLUMN, DOWNLOADING_FAILED_MESSAGE);
+                        item.setImage(STATUS_COLUMN, FileMoveIcon.FAIL.icon);
+                        item.setChecked(false);
+                    }
+                }
+            });
+    }
+
     @Override
     public void addEpisodes(Queue<FileEpisode> episodes) {
         // Update the list of ignored keywords
@@ -660,31 +687,12 @@ public class UIStarter implements Observer,  AddEpisodeListener {
             ShowStore.getShow(showName, new ShowInformationListener() {
                     @Override
                     public void downloaded(Show show) {
-                        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
-                        display.asyncExec(new Runnable() {
-                                @Override
-                                public void run() {
-                                    if ( tableContainsTableItem(item) ) {
-                                        item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
-                                        item.setImage(STATUS_COLUMN, FileMoveIcon.ADDED.icon);
-                                    }
-                                }
-                            });
+                        tableItemDownloaded(item, episode);
                     }
 
                     @Override
                     public void downloadFailed(Show show) {
-                        episode.setStatus(EpisodeStatus.BROKEN);
-                        display.asyncExec(new Runnable() {
-                                @Override
-                                public void run() {
-                                    if ( tableContainsTableItem(item) ) {
-                                        item.setText(NEW_FILENAME_COLUMN, DOWNLOADING_FAILED_MESSAGE);
-                                        item.setImage(STATUS_COLUMN, FileMoveIcon.FAIL.icon);
-                                        item.setChecked(false);
-                                    }
-                                }
-                            });
+                        tableItemFailed(item, episode);
                     }
                 });
         }

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -69,7 +69,7 @@ public class FileEpisodeTest {
         episode.setSeasonNum(seasonNum);
         episode.setEpisodeNum(episodeNum);
         episode.setFilenameResolution(resolution);
-        episode.setStatus(EpisodeStatus.DOWNLOADED);
+        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
 
         String newFilename = episode.getReplacementText();
 
@@ -105,7 +105,7 @@ public class FileEpisodeTest {
         episode.setSeasonNum(seasonNum);
         episode.setEpisodeNum(episodeNum);
         episode.setFilenameResolution(resolution);
-        episode.setStatus(EpisodeStatus.DOWNLOADED);
+        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
 
         String newFilename = episode.getReplacementText();
 

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -71,7 +71,7 @@ public class FileEpisodeTest {
         episode.setFilenameResolution(resolution);
         episode.setStatus(EpisodeStatus.DOWNLOADED);
 
-        String newFilename = episode.getNewFilename();
+        String newFilename = episode.getReplacementText();
 
         assertEquals("The Simpsons [5x10] $pringfield 720p.avi", newFilename);
     }
@@ -107,7 +107,7 @@ public class FileEpisodeTest {
         episode.setFilenameResolution(resolution);
         episode.setStatus(EpisodeStatus.DOWNLOADED);
 
-        String newFilename = episode.getNewFilename();
+        String newFilename = episode.getReplacementText();
 
         assertFalse("Resulting filename must not contain a ':' as it breaks Windows", newFilename.contains(":"));
     }


### PR DESCRIPTION
There are two separate steps to getting the listings for an episode:
(1) Looking at the filename, try to figure out what show it refers to.  We extract part of the filename, and normalize it, and use that result as a kind of a key.  We then send that text to TheTVDB, asking for shows with that name, and it returns zero or more options.  We try to choose the best one, create a Show object for it, and associate that "key" (the normalized text extracted from the filename) with that show.
(2) With the Show in hand, get its ID, and download the listings from TheTVDB for the show with that ID.

So, they are two separate steps, and really, they're kind of different.  The first one is a query: we're trying to figure stuff out.  The second one is a straight download.

Moreover, the second one really should be "keyed" by the show ID (or the show object), not by the text extracted from the filename.  That part was only necessary when we didn't have anything better to key upon.  In fact, the old approach could lead to a lot of superfluous downloading.  If we have a bunch of episodes, they might have slight differences (inclusion/exclusion of the word "the", slight typos) that still map to the same show.  But we're downloading listings for each show name, rather than each ID.

But another reason to separate them is that it's very possible for the first step to succeed and the second step to fail.  In this case, we might want to display a different type of failure to the user.

Also, in the case where a download fails due to the server being overloaded, if we want to do some sort of automatic retry, we should know what specifically failed.

It also makes a difference if we start to cache the files.  Step 1 is basically a mapping from text in the filename, to a show ID.  That is unlikely to change, and can be cached for long periods.  Step 2 would vary; if we detected the last episode of a show aired years ago, then the listings could probably safely be cached indefinitely; but if we see it's an active show, we'd want to decache the file frequently.

So, these are some of the reasons I'm splitting it up into two separate, discrete steps in the code.