### PR TITLE
Process episodes outside of TheTVDBProvider.

### DIFF
--- a/src/main/org/tvrenamer/model/Episode.java
+++ b/src/main/org/tvrenamer/model/Episode.java
@@ -1,33 +1,106 @@
 package org.tvrenamer.model;
 
+import org.tvrenamer.controller.util.StringUtils;
+
 import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.logging.Logger;
 
 public class Episode {
-    private final int seasonNum;
-    private final int episodeNum;
-    private final String title;
-    private final LocalDate airDate;
+    private static Logger logger = Logger.getLogger(Episode.class.getName());
 
-    public Episode(int seasonNum, int episodeNum, String title, LocalDate airDate) {
-        this.seasonNum = seasonNum;
-        this.episodeNum = episodeNum;
-        this.title = title;
-        this.airDate = airDate;
+    private static final String EPISODE_DATE_FORMAT = "yyyy-MM-dd";
+    // Unlike java.text.DateFormat, DateTimeFormatter is thread-safe, so we can create just one instance here.
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(EPISODE_DATE_FORMAT);
+
+    private final String title;
+    private final String airDateString;
+    private LocalDate firstAired = null;
+
+    private final String seasonNumber;
+    private final String episodeNumber;
+    private final String dvdSeason;
+    private final String dvdEpisodeNumber;
+
+
+    public Episode(EpisodeInfo info) {
+        this.title = info.episodeName;
+        this.airDateString = info.firstAired;
+        this.seasonNumber = info.seasonNumber;
+        this.episodeNumber = info.episodeNumber;
+        this.dvdSeason = info.dvdSeason;
+        this.dvdEpisodeNumber = info.dvdEpisodeNumber;
     }
 
     public String getTitle() {
         return title;
     }
 
+    public String getSeasonNumber() {
+        return seasonNumber;
+    }
+
+    public String getEpisodeNumber() {
+        return episodeNumber;
+    }
+
+    public String getDvdSeasonNumber() {
+        return dvdSeason;
+    }
+
+    public String getDvdEpisodeNumber() {
+        return dvdEpisodeNumber;
+    }
+
     public LocalDate getAirDate() {
-        return airDate;
+        if (firstAired == null) {
+            if (StringUtils.isBlank(airDateString)) {
+                // When no value (good or bad) is found, use "now".
+                firstAired = LocalDate.now();
+            } else {
+                try {
+                    firstAired = LocalDate.parse(airDateString, DATE_FORMATTER);
+                } catch (DateTimeParseException e) {
+                    // While a null or empty string is not considered an error,
+                    // a badly formatted string is.
+                    logger.severe("could not parse as date: " + airDateString);
+                    firstAired = LocalDate.now();
+                }
+            }
+        }
+        return firstAired;
+    }
+
+    // "Package-private".  Used by Show; should not be used by other classes.
+    String getDifferenceMessage(EpisodeInfo info) {
+        if (title.equals(info.episodeName)) {
+            if (airDateString.equals(info.firstAired)) {
+                return null;
+            } else {
+                return "different airdate: " + info.episodeName
+                    + " was " + airDateString
+                    + ", now " + info.firstAired;
+            }
+        } else {
+            if (airDateString.equals(info.firstAired)) {
+                return "different title: " + info.episodeId
+                    + " was " + title
+                    + ", now " + info.episodeName;
+            } else {
+                return "different title: " + info.episodeId
+                    + " was " + title
+                    + ", now " + info.episodeName
+                    + " and different airdate: " + info.episodeName
+                    + " was " + airDateString
+                    + ", now " + info.firstAired;
+            }
+        }
     }
 
     @Override
     public String toString() {
-        return "Episode S" + seasonNum
-            + "E" + episodeNum
-            + "[episodeName=" + title
-            + ", firstAired=" + airDate + "]";
+        return "Episode " + title
+            + ", firstAired=" + getAirDate() + "]";
     }
 }

--- a/src/main/org/tvrenamer/model/EpisodeInfo.java
+++ b/src/main/org/tvrenamer/model/EpisodeInfo.java
@@ -1,0 +1,97 @@
+package org.tvrenamer.model;
+
+public class EpisodeInfo {
+
+    public final String episodeId;
+    public final String seasonNumber;
+    public final String episodeNumber;
+    public final String episodeName;
+    public final String firstAired;
+    // public final String overview;
+    // public final String productionCode;
+    // public final String language;
+    // public final String id;
+    // public final String seriesid;
+    // public final String seasonid;
+    // public final String lastupdated;
+    public final String dvdSeason;
+    public final String dvdEpisodeNumber;
+    public final String absoluteNumber;
+    public final String seriesId;
+
+    public static class Builder {
+        private String episodeId;
+        private String seasonNumber;
+        private String episodeNumber;
+        private String episodeName;
+        private String firstAired;
+        private String dvdSeason;
+        private String dvdEpisodeNumber;
+        private String absoluteNumber;
+        private String seriesId;
+
+        public Builder() {
+        }
+
+        public Builder episodeId(String val) {
+            episodeId = val;
+            return this;
+        }
+
+        public Builder seasonNumber(String val) {
+            seasonNumber = val;
+            return this;
+        }
+
+        public Builder episodeNumber(String val) {
+            episodeNumber = val;
+            return this;
+        }
+
+        public Builder episodeName(String val) {
+            episodeName = val;
+            return this;
+        }
+
+        public Builder firstAired(String val) {
+            firstAired = val;
+            return this;
+        }
+
+        public Builder dvdSeason(String val) {
+            dvdSeason = val;
+            return this;
+        }
+
+        public Builder dvdEpisodeNumber(String val) {
+            dvdEpisodeNumber = val;
+            return this;
+        }
+
+        public Builder absoluteNumber(String val) {
+            absoluteNumber = val;
+            return this;
+        }
+
+        public Builder seriesId(String val) {
+            seriesId = val;
+            return this;
+        }
+
+        public EpisodeInfo build() {
+            return new EpisodeInfo(this);
+        }
+    }
+
+    public EpisodeInfo(Builder builder) {
+        episodeId = builder.episodeId;
+        seasonNumber = builder.seasonNumber;
+        episodeNumber = builder.episodeNumber;
+        episodeName = builder.episodeName;
+        firstAired = builder.firstAired;
+        dvdSeason = builder.dvdSeason;
+        dvdEpisodeNumber = builder.dvdEpisodeNumber;
+        absoluteNumber = builder.absoluteNumber;
+        seriesId = builder.seriesId;
+    }
+}

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -2,11 +2,10 @@ package org.tvrenamer.model;
 
 import org.tvrenamer.controller.util.StringUtils;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
 
 /**
@@ -18,13 +17,23 @@ public class Show implements Comparable<Show> {
     public static final int NO_SEASON = -1;
     public static final int NO_EPISODE = 0;
 
+    private enum NumberingScheme {
+        GUESS,
+        REGULAR,
+        DVD_RELEASE,
+        ABSOLUTE
+    }
+
     private final String id;
     private final String name;
     private final String dirName;
     private final String url;
 
-    private final List<Episode> episodes;
+    private final Map<String, Episode> episodes;
     private final Map<Integer, Map<Integer, Episode>> seasons;
+
+    // Not final.  Could be changed during the program's run.
+    private NumberingScheme numberingScheme = NumberingScheme.GUESS;
 
     public Show(String id, String name, String url) {
         this.id = id;
@@ -32,8 +41,8 @@ public class Show implements Comparable<Show> {
         this.url = url;
         dirName = StringUtils.sanitiseTitle(name);
 
-        episodes = new ArrayList<>();
-        seasons = new HashMap<>();
+        episodes = new ConcurrentHashMap<>();
+        seasons = new ConcurrentHashMap<>();
     }
 
     public String getId() {
@@ -53,16 +62,19 @@ public class Show implements Comparable<Show> {
     }
 
     private void addEpisodeToSeason(int seasonNum, int episodeNum, Episode episode) {
+        // Check to see if there's already an existing episode.  Only applies if we
+        // have a valid season number and episode number.
         Map<Integer, Episode> season = seasons.get(seasonNum);
         if (season == null) {
-            season = new HashMap<>();
+            season = new ConcurrentHashMap<>();
             seasons.put(seasonNum, season);
         }
         Episode found = season.remove(episodeNum);
         if (found == null) {
-            // normal, expected case: first time we're encountering the episode
+            // This is the expected case; we should only be adding the episode to
+            // the index a single time.
             season.put(episodeNum, episode);
-        } else if (found == episode) {
+        } else  if (found == episode) {
             // Well, this is unfortunate; if it happens, investigate why.  But it's
             // fine.  We still have a unique object.
             season.put(episodeNum, episode);
@@ -87,30 +99,127 @@ public class Show implements Comparable<Show> {
         }
     }
 
-    public void addEpisode(String seasonString, int episodeNum,
-                           String title, LocalDate firstAired)
-    {
-        int seasonNum = NO_SEASON;
-        try {
-            seasonNum = Integer.parseInt(seasonString);
-        } catch (NumberFormatException nfe) {
-            // Note, in this case, the Episode will be created and will be added to the
-            // list of episodes, but will not be added to the season/episode organization.
-            logger.info("episode \"" + title + "\" of show " + name
-                        + " has non-numeric season: " + seasonString);
-        }
-        Episode episode = null;
-        if (seasonNum > NO_SEASON) {
-            Map<Integer, Episode> season = seasons.get(seasonNum);
-            if (season != null) {
-                episode = season.get(episodeNum);
+    private void indexEpisodesBySeason(NumberingScheme effective) {
+        for (Episode episode : episodes.values()) {
+            if (episode == null) {
+                logger.severe("internal error creating episodes for " + name);
+                return;
             }
-        }
-        if (episode == null) {
-            episode = new Episode(seasonNum, episodeNum, title, firstAired);
-            episodes.add(episode);
+
+            String seasonNumString;
+            String episodeNumString;
+            if (effective == NumberingScheme.REGULAR) {
+                seasonNumString = episode.getSeasonNumber();
+                episodeNumString = episode.getEpisodeNumber();
+            } else if (effective == NumberingScheme.DVD_RELEASE) {
+                logger.info("using dvd information");
+                seasonNumString = episode.getDvdSeasonNumber();
+                episodeNumString = episode.getDvdEpisodeNumber();
+            } else {
+                // not supported
+                seasonNumString = "";
+                episodeNumString = "";
+            }
+
+            Integer seasonNum = StringUtils.stringToInt(seasonNumString);
+            Integer episodeNum = StringUtils.stringToInt(episodeNumString);
+
+            if ((seasonNum == null) || (episodeNum == null)) {
+                // Note, in this case, the Episode will be created and will be added to the
+                // list of episodes, but will not be added to the season/episode organization.
+                logger.info("episode \"" + episode.getTitle() + "\" of show " + name
+                            + " has non-numeric season: " + seasonNumString);
+                continue;
+            }
+
             addEpisodeToSeason(seasonNum, episodeNum, episode);
         }
+    }
+
+    private void indexEpisodesBySeason() {
+        if (numberingScheme == NumberingScheme.GUESS) {
+            int withDVD = 0;
+            int withoutDVD = 0;
+            for (Episode episode : episodes.values()) {
+                if (episode == null) {
+                    logger.severe("internal error creating episodes for " + name);
+                    return;
+                }
+
+                Integer seasonNum = StringUtils.stringToInt(episode.getDvdSeasonNumber());
+                Integer episodeNum = StringUtils.stringToInt(episode.getDvdEpisodeNumber());
+
+                if ((seasonNum == null) || (episodeNum == null)) {
+                    withoutDVD++;
+                } else {
+                    withDVD++;
+                }
+            }
+            // Make the threshold 50%.  That's probably low, but the program has a history
+            // of preferring DVD episode numbers, and 50% is really easy to do.
+            if (withDVD > withoutDVD) {
+                indexEpisodesBySeason(NumberingScheme.DVD_RELEASE);
+            } else {
+                indexEpisodesBySeason(NumberingScheme.REGULAR);
+            }
+        } else {
+            indexEpisodesBySeason(numberingScheme);
+        }
+    }
+
+    private void dealWithConflicts(List<EpisodeInfo> conflicts) {
+        for (EpisodeInfo info : conflicts) {
+            Episode episode = episodes.get(info.episodeId);
+            String msg = episode.getDifferenceMessage(info);
+            if (msg == null) {
+                logger.warning("handling again: " + info.episodeName);
+            } else {
+                logger.warning(msg);
+            }
+        }
+    }
+
+    public void addEpisodes(final EpisodeInfo[] infos) {
+        List<EpisodeInfo> conflicts = new LinkedList<>();
+        for (EpisodeInfo info : infos) {
+            if (info != null) {
+                String episodeId = info.episodeId;
+                Episode existing = episodes.get(episodeId);
+                if (existing == null) {
+                    Episode episode = new Episode(info);
+                    episodes.put(episodeId, episode);
+                } else {
+                    conflicts.add(info);
+                }
+            }
+        }
+        indexEpisodesBySeason();
+        dealWithConflicts(conflicts);
+    }
+
+    public synchronized void preferHeuristicOrdering() {
+        seasons.clear();
+        numberingScheme = NumberingScheme.GUESS;
+        indexEpisodesBySeason();
+    }
+
+    public synchronized void preferProductionOrdering() {
+        seasons.clear();
+        numberingScheme = NumberingScheme.REGULAR;
+        indexEpisodesBySeason(NumberingScheme.REGULAR);
+    }
+
+    public synchronized void preferDvdOrdering() {
+        seasons.clear();
+        numberingScheme = NumberingScheme.DVD_RELEASE;
+        indexEpisodesBySeason(NumberingScheme.DVD_RELEASE);
+    }
+
+    // Private -- not supported -- haven't tested.  TODO.
+    private synchronized void preferAbsoluteOrdering() {
+        seasons.clear();
+        numberingScheme = NumberingScheme.ABSOLUTE;
+        indexEpisodesBySeason(NumberingScheme.ABSOLUTE);
     }
 
     public Episode getEpisode(int seasonNum, int episodeNum) {
@@ -119,7 +228,11 @@ public class Show implements Comparable<Show> {
             logger.warning("no season " + seasonNum + " found for show " + name);
             return null;
         }
-        return season.get(episodeNum);
+        Episode episode = season.get(episodeNum);
+        logger.info("for season " + seasonNum + ", episode " + episodeNum
+                    + ", found " + episode);
+
+        return episode;
     }
 
     public boolean hasSeasons() {
@@ -143,5 +256,4 @@ public class Show implements Comparable<Show> {
     public int compareTo(Show other) {
         return Integer.parseInt(other.id) - Integer.parseInt(this.id);
     }
-
 }

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -63,12 +63,57 @@ public class TheTVDBProviderTest {
 
         TheTVDBProvider.getShowListing(best);
 
+        best.preferProductionOrdering();
         Episode s1e02 = best.getEpisode(1, 2);
-        assertNotNull(s1e02);
+        assertNotNull("result of calling getEpisode(1, 2) on " + showName + " came back null",
+                      s1e02);
         assertEquals(ep2Name, s1e02.getTitle());
 
         // This is probably too likely to change.
         // assertEquals(1, options.size());
+    }
+
+    /**
+     * Second download test.  This one is specifically chosen to ensure we
+     * get the right preferences between "DVD number" and "regular number".
+     */
+    @Test
+    public void testRegularEpisodePreference() throws Exception {
+        final String showName = "Firefly";
+        final String showId = "78874";
+        final String dvdName = "The Train Job";
+        final String productionName = "Bushwhacked";
+
+        List<Show> options = TheTVDBProvider.getShowOptions(showName);
+        assertNotNull(options);
+        assertNotEquals(0, options.size());
+        Show best = options.get(0);
+        assertNotNull(best);
+        assertEquals(showId, best.getId());
+        assertEquals(showName, best.getName());
+
+        best.preferDvdOrdering();
+        TheTVDBProvider.getShowListing(best);
+
+        Episode s01e02 = null;
+
+        best.preferHeuristicOrdering();
+        s01e02 = best.getEpisode(1, 2);
+        assertNotNull("result of calling getEpisode(1, 2) on " + showName
+                      + "with heuristic ordering came back null", s01e02);
+        assertEquals(dvdName, s01e02.getTitle());
+
+        best.preferProductionOrdering();
+        s01e02 = best.getEpisode(1, 2);
+        assertNotNull("result of calling getEpisode(1, 2) on " + showName
+                      + " with production ordering came back null", s01e02);
+        assertEquals(productionName, s01e02.getTitle());
+
+        best.preferDvdOrdering();
+        s01e02 = best.getEpisode(1, 2);
+        assertNotNull("result of calling getEpisode(1, 2) on " + showName
+                      + " with DVD ordering came back null", s01e02);
+        assertEquals(dvdName, s01e02.getTitle());
     }
 
     private static class TestInput {

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -15,7 +15,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -66,11 +65,20 @@ public class FileEpisodeTest {
 
         String showName = "The Simpsons";
         Show show = new Show("71663", showName, "http://thetvdb.com/?tab=series&id=71663");
+        show.preferProductionOrdering();
         ShowStore.addShow(filenameShow, show);
 
         String title = "$pringfield";
-        show.addEpisode(seasonNumString, Integer.parseInt(episodeNumString),
-                        title, LocalDate.now());
+        EpisodeInfo info = new EpisodeInfo.Builder()
+            .episodeId("55542")
+            .seasonNumber(seasonNumString)
+            .episodeNumber(episodeNumString)
+            .episodeName(title)
+            .build();
+        EpisodeInfo[] dummyArray = new EpisodeInfo[1];
+        dummyArray[0] = info;
+        show.addEpisodes(dummyArray);
+
         episode.setStatus(EpisodeStatus.GOT_LISTINGS);
 
         assertEquals("The Simpsons [5x10] $pringfield 720p.avi",
@@ -101,11 +109,19 @@ public class FileEpisodeTest {
 
         String showName = "Steven Seagal: Lawman";
         Show show = new Show("126841", showName, "http://thetvdb.com/?tab=series&id=126841&lid=7");
+        show.preferProductionOrdering();
         ShowStore.addShow(filenameShow, show);
 
         String title = "The Way of the Gun";
-        show.addEpisode(seasonNumString, Integer.parseInt(episodeNumString),
-                        title, LocalDate.now());
+        EpisodeInfo info = new EpisodeInfo.Builder()
+            .episodeId("1111")
+            .seasonNumber(seasonNumString)
+            .episodeNumber(episodeNumString)
+            .episodeName(title)
+            .build();
+        EpisodeInfo[] dummyArray = new EpisodeInfo[1];
+        dummyArray[0] = info;
+        show.addEpisodes(dummyArray);
         episode.setStatus(EpisodeStatus.GOT_LISTINGS);
 
         String newFilename = episode.getReplacementText();


### PR DESCRIPTION
Add EpisodeInfo to hold the text we extract about an episode.  It's more of a structure/record than a real class, with no methods and public variables.  It uses a builder to make it clearer which values are being put where.  So, now TheTVDBProvider uses the EpisodeInfo Builder to package up the strings it extracts from the XML, and is done.  It doesn't process the strings any more.

It does get a few more fields than it used to, though.  We're now getting the episode ID, the series ID for the episode, and the DVD season number, all of which go into the EpisodeInfo.

The Show class gets all the EpisodeInfo instances we create.  It processes the season number and episode number based on a per-show setting (although as of this commit, there's no way for the user to override the setting).  It then creates the episode, with the season and episode numbers it has determined to be the preferred ones.

The Episode is now responsible for turning its date string into a LocalDate.  If we expand it to include other types of non-String information, that processing should also be done inside the Episode.

Add a test to verify that the indexing works with both regular and DVD numbering, and that the DVD ordering is preferred when it is available.