### PR TITLE
add structure for renaming tests, and many tests

### DIFF
--- a/etc/logging.properties
+++ b/etc/logging.properties
@@ -1,18 +1,18 @@
 # The JDK logging properties file, intended for development only
 # Example from http://www.java2s.com/Code/Java/Language-Basics/ConfiguringLoggerDefaultValueswithaPropertiesFile.htm
 
-# It is loaded by specifying the below property on the command line:
-# -Djava.util.logging.config.file=etc/logging.properties
+# It is loaded by the Launcher class, in its static initialization block.  The build.xml ant file copies
+# this file to the right place so that the Launcher will be able to find it.
 
 # The following creates two handlers
 handlers = org.tvrenamer.model.util.StdOutConsoleHandler
 
 # Set the default formatter for new ConsoleHandler instances
 org.tvrenamer.model.util.StdOutConsoleHandler.formatter = org.tvrenamer.model.util.StdOutConsoleFormatter
-    
+
 # Set the default logging level for the root logger
 # one of: ALL, FINEST, FINER, FINE, CONFIG, INFO, WARNING, SEVERE, OFF
-.level = FINE
+.level = INFO
 
 sun.awt.level = OFF
 java.awt.level = OFF

--- a/src/main/org/tvrenamer/controller/TVRenamer.java
+++ b/src/main/org/tvrenamer/controller/TVRenamer.java
@@ -84,7 +84,7 @@ public class TVRenamer {
 
     static String insertShowNameIfNeeded(final Path filePath) {
         String pName = filePath.getFileName().toString();
-        logger.info("pName = " + pName);
+        logger.fine("pName = " + pName);
         if (pName.matches("[sS]\\d\\d?[eE]\\d\\d?.*")) {
             Path parent = filePath.getParent();
             String parentName = parent.getFileName().toString();

--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -58,7 +58,7 @@ public class TheTVDBProvider {
     {
         String searchURL = BASE_SEARCH_URL + StringUtils.encodeSpecialCharacters(showName);
 
-        logger.info("About to download search results from " + searchURL);
+        logger.fine("About to download search results from " + searchURL);
 
         String searchXmlText = new HttpConnectionHandler().downloadUrl(searchURL);
         return searchXmlText;
@@ -69,7 +69,7 @@ public class TheTVDBProvider {
     {
         String showURL = BASE_LIST_URL + show.getId() + BASE_LIST_FILENAME;
 
-        logger.info("Downloading episode listing from " + showURL);
+        logger.fine("Downloading episode listing from " + showURL);
 
         String listingXmlText = new HttpConnectionHandler().downloadUrl(showURL);
         return listingXmlText;

--- a/src/main/org/tvrenamer/controller/util/FileUtilities.java
+++ b/src/main/org/tvrenamer/controller/util/FileUtilities.java
@@ -128,6 +128,16 @@ public class FileUtilities {
         }
     }
 
+    public static boolean isSameFile(final Path path1, final Path path2) {
+        try {
+            return Files.isSameFile(path1, path2);
+        } catch (IOException ioe) {
+            logger.log(Level.WARNING, "exception checking files "
+                       + path1 + " and " + path2, ioe);
+            return false;
+        }
+    }
+
     public static boolean mkdirs(final Path dir) {
         try {
             Files.createDirectories(dir);

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -112,7 +112,6 @@ public class Show implements Comparable<Show> {
                 seasonNumString = episode.getSeasonNumber();
                 episodeNumString = episode.getEpisodeNumber();
             } else if (effective == NumberingScheme.DVD_RELEASE) {
-                logger.info("using dvd information");
                 seasonNumString = episode.getDvdSeasonNumber();
                 episodeNumString = episode.getDvdEpisodeNumber();
             } else {
@@ -127,7 +126,7 @@ public class Show implements Comparable<Show> {
             if ((seasonNum == null) || (episodeNum == null)) {
                 // Note, in this case, the Episode will be created and will be added to the
                 // list of episodes, but will not be added to the season/episode organization.
-                logger.info("episode \"" + episode.getTitle() + "\" of show " + name
+                logger.fine("episode \"" + episode.getTitle() + "\" of show " + name
                             + " has non-numeric season: " + seasonNumString);
                 continue;
             }
@@ -229,7 +228,7 @@ public class Show implements Comparable<Show> {
             return null;
         }
         Episode episode = season.get(episodeNum);
-        logger.info("for season " + seasonNum + ", episode " + episodeNum
+        logger.fine("for season " + seasonNum + ", episode " + episodeNum
                     + ", found " + episode);
 
         return episode;

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
 
     public static final Path USER_HOME_DIR = Paths.get(Environment.USER_HOME);
     public static final Path WORKING_DIRECTORY = Paths.get(Environment.USER_DIR);
+    public static final Path TMP_DIR = Paths.get(Environment.TMP_DIR_NAME);
 
     public static final Path DEFAULT_DESTINATION_DIRECTORY = USER_HOME_DIR.resolve("TV");
     public static final Path CONFIGURATION_DIRECTORY = USER_HOME_DIR.resolve(CONFIGURATION_DIRECTORY_NAME);

--- a/src/main/org/tvrenamer/model/util/Environment.java
+++ b/src/main/org/tvrenamer/model/util/Environment.java
@@ -10,6 +10,7 @@ public class Environment {
     public static final String USER_HOME = System.getProperty("user.home");
     public static final String USER_DIR = System.getProperty("user.dir");
     public static final String OS_NAME = System.getProperty("os.name");
+    public static final String TMP_DIR_NAME = System.getProperty("java.io.tmpdir");
 
     private enum OSType {
         WINDOWS,

--- a/src/test/org/tvrenamer/model/EpisodeTestData.java
+++ b/src/test/org/tvrenamer/model/EpisodeTestData.java
@@ -1,0 +1,139 @@
+package org.tvrenamer.model;
+
+import java.util.logging.Logger;
+
+public class EpisodeTestData {
+    private static Logger logger = Logger.getLogger(EpisodeTestData.class.getName());
+
+    public final String filenameShow;
+    public final String properShowName;
+    public final String showId;
+    public final String seasonNumString;
+    public final String episodeNumString;
+    public final String episodeResolution;
+    public final String episodeTitle;
+    public final String episodeId;
+    public final String separator;
+    public final String filenameSuffix;
+    public final String replacementMask;
+    public final String expectedReplacement;
+    public final String inputFilename;
+    public final String documentation;
+
+    public static class Builder {
+        private String filenameShow;
+        private String properShowName;
+        private String showId = "1";
+        private String seasonNumString;
+        private String episodeNumString;
+        private String episodeResolution = "";
+        private String episodeTitle;
+        private String episodeId = "100";
+        private String separator = ".";
+        private String filenameSuffix = ".avi";
+        private String replacementMask = "%S [%sx%e] %t";
+        private String expectedReplacement;
+        private String documentation = null;
+
+        public Builder() {
+        }
+
+        public Builder filenameShow(String val) {
+            filenameShow = val;
+            return this;
+        }
+
+        public Builder properShowName(String val) {
+            properShowName = val;
+            return this;
+        }
+
+        public Builder showId(String val) {
+            showId = val;
+            return this;
+        }
+
+        public Builder seasonNumString(String val) {
+            seasonNumString = val;
+            return this;
+        }
+
+        public Builder episodeNumString(String val) {
+            episodeNumString = val;
+            return this;
+        }
+
+        public Builder episodeResolution(String val) {
+            episodeResolution = val;
+            return this;
+        }
+
+        public Builder episodeTitle(String val) {
+            episodeTitle = val;
+            return this;
+        }
+
+        public Builder episodeId(String val) {
+            episodeId = val;
+            return this;
+        }
+
+        public Builder filenameSuffix(String val) {
+            filenameSuffix = val;
+            return this;
+        }
+
+        public Builder separator(String val) {
+            separator = val;
+            return this;
+        }
+
+        public Builder replacementMask(String val) {
+            replacementMask = val;
+            return this;
+        }
+
+        public Builder expectedReplacement(String val) {
+            expectedReplacement = val;
+            return this;
+        }
+
+        public Builder documentation(String val) {
+            documentation = val;
+            return this;
+        }
+
+        public EpisodeTestData build() {
+            return new EpisodeTestData(this);
+        }
+    }
+
+    public EpisodeTestData(Builder builder) {
+        filenameShow = builder.filenameShow;
+        properShowName = builder.properShowName;
+        showId = builder.showId;
+        seasonNumString = builder.seasonNumString;
+        episodeNumString = builder.episodeNumString;
+        episodeResolution = builder.episodeResolution;
+        episodeTitle = builder.episodeTitle;
+        episodeId = builder.episodeId;
+        separator = builder.separator;
+        filenameSuffix = builder.filenameSuffix;
+        replacementMask = builder.replacementMask;
+        expectedReplacement = builder.expectedReplacement;
+        documentation = builder.documentation;
+        String resolutionString = "";
+        if ((episodeResolution != null) && (episodeResolution.length() > 0)) {
+            resolutionString = separator + episodeResolution;
+        }
+        inputFilename = filenameShow
+            + separator + seasonNumString
+            + separator + episodeNumString
+            + resolutionString + filenameSuffix;
+    }
+
+    @Override
+    public String toString() {
+        return "EpisodeTestData[" + inputFilename + "]";
+    }
+}

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -136,7 +136,7 @@ public class FileEpisodeTest {
     @After
     public void teardown() throws Exception {
         for (Path path : testFiles) {
-            logger.info("Deleting " + path);
+            logger.fine("Deleting " + path);
             FileUtilities.deleteFile(path);
         }
     }

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -2,6 +2,8 @@ package org.tvrenamer.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+import static org.tvrenamer.model.util.Constants.*;
 
 import org.junit.After;
 import org.junit.Before;
@@ -12,7 +14,6 @@ import org.tvrenamer.controller.util.FileUtilities;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Logger;
@@ -20,15 +21,18 @@ import java.util.logging.Logger;
 public class FileEpisodeTest {
     private static Logger logger = Logger.getLogger(FileEpisodeTest.class.getName());
 
-    private static final String TEMP_DIR_NAME = System.getProperty("java.io.tmpdir");
-    private static final Path TEMP_DIR = Paths.get(TEMP_DIR_NAME);
-
+    private Path ourTempDir;
     private List<Path> testFiles;
 
     private UserPreferences prefs;
 
     @Before
     public void setUp() throws Exception {
+        ourTempDir = TMP_DIR.resolve(APPLICATION_NAME);
+        boolean madeDir = FileUtilities.mkdirs(ourTempDir);
+        if (false == madeDir) {
+            fail("unable to create temp directory " + ourTempDir);
+        }
         testFiles = new ArrayList<>();
         prefs = UserPreferences.getInstance();
         prefs.setMoveEnabled(false);
@@ -50,7 +54,7 @@ public class FileEpisodeTest {
 
         String filename = filenameShow + "." + seasonNumString + "."
             + episodeNumString + "." + resolution + ".avi";
-        Path path = TEMP_DIR.resolve(filename);
+        Path path = ourTempDir.resolve(filename);
         createFile(path);
 
         FileEpisode episode = new FileEpisode(path);
@@ -95,7 +99,7 @@ public class FileEpisodeTest {
 
         String filename = filenameShow + "." + seasonNumString + "."
             + episodeNumString + ".avi";
-        Path path = TEMP_DIR.resolve(filename);
+        Path path = ourTempDir.resolve(filename);
         createFile(path);
 
         FileEpisode episode = new FileEpisode(path);

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -1,12 +1,12 @@
 package org.tvrenamer.model;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.tvrenamer.model.util.Constants.*;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import org.tvrenamer.controller.util.FileUtilities;
@@ -26,6 +26,761 @@ public class FileEpisodeTest {
 
     private UserPreferences prefs;
 
+    public static final List<EpisodeTestData> values = new ArrayList<>();
+
+    // We're going to add a bunch of test cases to the list.  The first two have been in this file
+    // for a long time (in a different form), and are testing specific functionality.  The rest
+    // are from the TVRenamer test.  In some cases, there's a strong hint as to what they're
+    // testing, and in others, maybe not so much.  Try to refine these test cases down and expand
+    // them so that specific functionality is being tested.
+    //
+    // The "BeforeClass" annotation means any method so marked will be run before the tests, so
+    // we don't have to stuff it all into one huge method.  We can break it down arbitrarily.
+    // As we change the test data to be more meaningful, we could change the method names as well.
+
+    @BeforeClass
+    public static void setupValues() {
+        /**
+         * Test case for <a href="https://github.com/tvrenamer/tvrenamer/issues/36">Issue 36</a>
+         * where the title "$pringfield" breaks the regex used for String.replaceAll()
+         */
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("the.simpsons")
+                   .properShowName("The Simpsons")
+                   .showId("71663")
+                   .seasonNumString("5")
+                   .episodeNumString("10")
+                   .episodeResolution("720p")
+                   .episodeTitle("$pringfield")
+                   .episodeId("55542")
+                   .replacementMask("%S [%sx%e] %t %r")
+                   .expectedReplacement("The Simpsons [5x10] $pringfield 720p.avi")
+                   .build());
+        /**
+         * Ensure that colons (:) don't make it into the renamed filename <br />
+         * Fixes <a href="https://github.com/tvrenamer/tvrenamer/issues/46">Issue 46</a>
+         */
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("steven.segal.lawman")
+                   .properShowName("Steven Seagal: Lawman")
+                   .showId("126841")
+                   .seasonNumString("1")
+                   .episodeNumString("01")
+                   .episodeTitle("The Way of the Gun")
+                   .replacementMask("%S [%sx%e] %t")
+                   .expectedReplacement("Steven Seagal - Lawman [1x1] The Way of the Gun.avi")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues03() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("nip tuck")
+                   .properShowName("Nip/Tuck")
+                   .seasonNumString("6")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Don Hoberman")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Nip-Tuck S06E01 Don Hoberman.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("human target 2010")
+                   .properShowName("Human Target (2010)")
+                   .seasonNumString("1")
+                   .episodeNumString("2")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Rewind")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Human Target (2010) S01E02 Rewind.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("castle 2009")
+                   .properShowName("Castle (2009)")
+                   .seasonNumString("1")
+                   .episodeNumString("9")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Little Girl Lost")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Castle (2009) S01E09 Little Girl Lost.mkv")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues04() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("reign 2013")
+                   .properShowName("Reign (2013)")
+                   .seasonNumString("1")
+                   .episodeNumString("20")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Higher Ground")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Reign (2013) S01E20 Higher Ground.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("the americans 2013")
+                   .properShowName("The Americans (2013)")
+                   .seasonNumString("2")
+                   .episodeNumString("10")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Yousaf")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("The Americans (2013) S02E10 Yousaf.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("house of cards us")
+                   .properShowName("House of Cards (US)")
+                   .seasonNumString("1")
+                   .episodeNumString("6")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Chapter 6")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("House of Cards (US) S01E06 Chapter 6.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues05() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("modern family")
+                   .properShowName("Modern Family")
+                   .seasonNumString("5")
+                   .episodeNumString("12")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Under Pressure")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Modern Family S05E12 Under Pressure.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("game of thrones")
+                   .properShowName("Game of Thrones")
+                   .seasonNumString("5")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("The Wars to Come")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Game of Thrones S05E01 The Wars to Come.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("24")
+                   .properShowName("24")
+                   .seasonNumString("8")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Day 8: 4:00 P.M. - 5:00 P.M.")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("24 S08E01 Day 8 - 4 -00 P.M. - 5 -00 P.M..mkv")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues06() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("24")
+                   .properShowName("24")
+                   .seasonNumString("7")
+                   .episodeNumString("18")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Day 7: 1:00 A.M. - 2:00 A.M.")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("24 S07E18 Day 7 - 1 -00 A.M. - 2 -00 A.M..mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("dexter")
+                   .properShowName("Dexter")
+                   .seasonNumString("4")
+                   .episodeNumString("7")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Slack Tide")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Dexter S04E07 Slack Tide.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("jag")
+                   .properShowName("JAG")
+                   .seasonNumString("10")
+                   .episodeNumString("1")
+                   .filenameSuffix(".avi")
+                   .episodeTitle("Hail and Farewell, Part II (2)")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("JAG S10E01 Hail and Farewell, Part II (2).avi")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues07() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("lost")
+                   .properShowName("Lost")
+                   .seasonNumString("6")
+                   .episodeNumString("5")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Lighthouse")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Lost S06E05 Lighthouse.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("warehouse 13")
+                   .properShowName("Warehouse 13")
+                   .seasonNumString("1")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Pilot")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Warehouse 13 S01E01 Pilot.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("one tree hill")
+                   .properShowName("One Tree Hill")
+                   .seasonNumString("7")
+                   .episodeNumString("14")
+                   .filenameSuffix(".avi")
+                   .episodeTitle("Family Affair")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("One Tree Hill S07E14 Family Affair.avi")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues08() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("gossip girl")
+                   .properShowName("Gossip Girl")
+                   .seasonNumString("3")
+                   .episodeNumString("15")
+                   .filenameSuffix(".avi")
+                   .episodeTitle("The Sixteen Year Old Virgin")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Gossip Girl S03E15 The Sixteen Year Old Virgin.avi")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("smallville")
+                   .properShowName("Smallville")
+                   .seasonNumString("9")
+                   .episodeNumString("14")
+                   .filenameSuffix(".avi")
+                   .episodeTitle("Conspiracy")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Smallville S09E14 Conspiracy.avi")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("smallville")
+                   .properShowName("Smallville")
+                   .seasonNumString("9")
+                   .episodeNumString("15")
+                   .filenameSuffix(".avi")
+                   .episodeTitle("Escape")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Smallville S09E15 Escape.avi")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues09() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("the big bang theory")
+                   .properShowName("The Big Bang Theory")
+                   .seasonNumString("3")
+                   .episodeNumString("18")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("The Pants Alternative")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("The Big Bang Theory S03E18 The Pants Alternative.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("dexter")
+                   .properShowName("Dexter")
+                   .seasonNumString("5")
+                   .episodeNumString("5")
+                   .filenameSuffix(".mkv")
+                   .episodeTitle("First Blood")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Dexter S05E05 First Blood.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("lost")
+                   .properShowName("Lost")
+                   .seasonNumString("2")
+                   .episodeNumString("7")
+                   .filenameSuffix(".mkv")
+                   .episodeTitle("The Other 48 Days")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Lost S02E07 The Other 48 Days.mkv")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues10() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("californication")
+                   .properShowName("Californication")
+                   .seasonNumString("7")
+                   .episodeNumString("4")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Dicks")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Californication S07E04 Dicks.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("continuum")
+                   .properShowName("Continuum")
+                   .seasonNumString("3")
+                   .episodeNumString("7")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Waning Minutes")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Continuum S03E07 Waning Minutes.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("elementary")
+                   .properShowName("Elementary")
+                   .seasonNumString("2")
+                   .episodeNumString("23")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Art in the Blood")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Elementary S02E23 Art in the Blood.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues11() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("family guy")
+                   .properShowName("Family Guy")
+                   .seasonNumString("12")
+                   .episodeNumString("19")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Meg Stinks!")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Family Guy S12E19 Meg Stinks!.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("fargo")
+                   .properShowName("Fargo")
+                   .seasonNumString("1")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("The Crocodile's Dilemma")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Fargo S01E01 The Crocodile's Dilemma.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("girls")
+                   .properShowName("Girls")
+                   .seasonNumString("3")
+                   .episodeNumString("11")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("I Saw You")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Girls S03E11 I Saw You.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues12() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("grimm")
+                   .properShowName("Grimm")
+                   .seasonNumString("3")
+                   .episodeNumString("19")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Nobody Knows the Trubel I've Seen")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Grimm S03E19 Nobody Knows the Trubel I've Seen.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("new girl")
+                   .properShowName("New Girl")
+                   .seasonNumString("3")
+                   .episodeNumString("23")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Cruise")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("New Girl S03E23 Cruise.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("nurse jackie")
+                   .properShowName("Nurse Jackie")
+                   .seasonNumString("6")
+                   .episodeNumString("4")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Jungle Love")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Nurse Jackie S06E04 Jungle Love.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues13() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("offspring")
+                   .properShowName("Offspring")
+                   .seasonNumString("5")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Back in the Game")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Offspring S05E01 Back in the Game.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("robot chicken")
+                   .properShowName("Robot Chicken")
+                   .seasonNumString("7")
+                   .episodeNumString("4")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Rebel Appliance")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Robot Chicken S07E04 Rebel Appliance.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("supernatural")
+                   .properShowName("Supernatural")
+                   .seasonNumString("9")
+                   .episodeNumString("21")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("King of the Damned")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Supernatural S09E21 King of the Damned.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues14() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("the big bang theory")
+                   .properShowName("The Big Bang Theory")
+                   .seasonNumString("7")
+                   .episodeNumString("23")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("The Gorilla Dissolution")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("The Big Bang Theory S07E23 The Gorilla Dissolution.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("the good wife")
+                   .properShowName("The Good Wife")
+                   .seasonNumString("5")
+                   .episodeNumString("20")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("The Deep Web")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("The Good Wife S05E20 The Deep Web.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("veep")
+                   .properShowName("Veep")
+                   .seasonNumString("3")
+                   .episodeNumString("5")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Fishing")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Veep S03E05 Fishing.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues15() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("witches of east end")
+                   .properShowName("Witches of East End")
+                   .seasonNumString("1")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Pilot")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Witches of East End S01E01 Pilot.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("warehouse 13")
+                   .properShowName("Warehouse 13")
+                   .seasonNumString("5")
+                   .episodeNumString("4")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Savage Seduction")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Warehouse 13 S05E04 Savage Seduction.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("the 100")
+                   .properShowName("The 100")
+                   .seasonNumString("2")
+                   .episodeNumString("8")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Spacewalker")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("The 100 S02E08 Spacewalker.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValuesFirefly() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("The Train Job")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E01 The Train Job.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("2")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Bushwhacked")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E02 Bushwhacked.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("3")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Our Mrs. Reynolds")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E03 Our Mrs. Reynolds.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("4")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Jaynestown")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E04 Jaynestown.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("5")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Out of Gas")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E05 Out of Gas.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("6")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Shindig")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E06 Shindig.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("7")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Safe")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E07 Safe.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("8")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Ariel")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E08 Ariel.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("9")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("War Stories")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E09 War Stories.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("10")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Objects in Space")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E10 Objects in Space.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("11")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Serenity")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E11 Serenity.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("12")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Heart of Gold")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E12 Heart of Gold.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("13")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("Trash")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E13 Trash.mp4")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("firefly")
+                   .properShowName("Firefly")
+                   .seasonNumString("1")
+                   .episodeNumString("14")
+                   .filenameSuffix(".mp4")
+                   .episodeTitle("The Message")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Firefly S01E14 The Message.mp4")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues17() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("strike back")
+                   .properShowName("Strike Back")
+                   .seasonNumString("1")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Chris Ryan's Strike Back, Episode 1")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Strike Back S01E01 Chris Ryan's Strike Back, Episode 1.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("ncis")
+                   .properShowName("NCIS")
+                   .seasonNumString("13")
+                   .episodeNumString("04")
+                   .filenameSuffix(".hdtv-lol")
+                   .episodeTitle("Double Trouble")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("NCIS S13E04 Double Trouble.hdtv-lol")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("lucifer")
+                   .properShowName("Lucifer")
+                   .seasonNumString("2")
+                   .episodeNumString("3")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Sin-Eater")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Lucifer S02E03 Sin-Eater.mkv")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues18() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("marvels agents of shield")
+                   .properShowName("Marvel's Agents of S.H.I.E.L.D.")
+                   .seasonNumString("4")
+                   .episodeNumString("3")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("1080p")
+                   .episodeTitle("Uprising")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Marvel's Agents of S.H.I.E.L.D. S04E03 Uprising.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("supernatural")
+                   .properShowName("Supernatural")
+                   .seasonNumString("11")
+                   .episodeNumString("22")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("1080p")
+                   .episodeTitle("We Happy Few")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Supernatural S11E22 We Happy Few.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("supernatural")
+                   .properShowName("Supernatural")
+                   .seasonNumString("11")
+                   .episodeNumString("22")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("We Happy Few")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Supernatural S11E22 We Happy Few.mkv")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValues19() {
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("channel zero")
+                   .properShowName("Channel Zero")
+                   .seasonNumString("1")
+                   .episodeNumString("1")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("480p")
+                   .episodeTitle("You Have to Go Inside")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("Channel Zero S01E01 You Have to Go Inside.mkv")
+                   .build());
+        values.add(new EpisodeTestData.Builder()
+                   .filenameShow("ncis")
+                   .properShowName("NCIS")
+                   .seasonNumString("14")
+                   .episodeNumString("4")
+                   .filenameSuffix(".mkv")
+                   .episodeResolution("720p")
+                   .episodeTitle("Love Boat")
+                   // .replacementMask("%S [%sx%e] %t %r")
+                   .replacementMask("%S S%0sE%0e %t")
+                   .expectedReplacement("NCIS S14E04 Love Boat.mkv")
+                   .build());
+    }
+
     @Before
     public void setUp() throws Exception {
         ourTempDir = TMP_DIR.resolve(APPLICATION_NAME);
@@ -39,102 +794,52 @@ public class FileEpisodeTest {
         prefs.setRenameEnabled(true);
     }
 
-    /**
-     * Test case for <a href="https://github.com/tvrenamer/tvrenamer/issues/36">Issue 36</a> where the title
-     * "$pringfield" breaks the regex used for String.replaceAll()
-     */
-    @Test
-    public void testGetNewFilenameSpecialRegexChars() throws Exception {
-        prefs.setRenameReplacementString("%S [%sx%e] %t %r");
+    private String getReplacementFilename(EpisodeTestData data)
+        throws IOException
+    {
+        prefs.setRenameReplacementString(data.replacementMask);
 
-        String filenameShow = "the.simpsons";
-        String seasonNumString = "5";
-        String episodeNumString = "10";
-        String resolution = "720p";
-
-        String filename = filenameShow + "." + seasonNumString + "."
-            + episodeNumString + "." + resolution + ".avi";
-        Path path = ourTempDir.resolve(filename);
-        createFile(path);
-
-        FileEpisode episode = new FileEpisode(path);
-        episode.setFilenameShow(filenameShow);
-        episode.setFilenameSeason(seasonNumString);
-        episode.setFilenameEpisode(episodeNumString);
-        episode.setFilenameResolution(resolution);
-
-        String showName = "The Simpsons";
-        Show show = new Show("71663", showName, "http://thetvdb.com/?tab=series&id=71663");
-        show.preferProductionOrdering();
-        ShowStore.addShow(filenameShow, show);
-
-        String title = "$pringfield";
-        EpisodeInfo info = new EpisodeInfo.Builder()
-            .episodeId("55542")
-            .seasonNumber(seasonNumString)
-            .episodeNumber(episodeNumString)
-            .episodeName(title)
-            .build();
-        EpisodeInfo[] dummyArray = new EpisodeInfo[1];
-        dummyArray[0] = info;
-        show.addEpisodes(dummyArray);
-
-        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
-
-        assertEquals("The Simpsons [5x10] $pringfield 720p.avi",
-                     episode.getReplacementText());
-    }
-
-    /**
-     * Ensure that colons (:) don't make it into the renamed filename <br />
-     * Fixes <a href="https://github.com/tvrenamer/tvrenamer/issues/46">Issue 46</a>
-     */
-    @Test
-    public void testColon() throws Exception {
-        prefs.setRenameReplacementString("%S [%sx%e] %t");
-
-        String filenameShow = "steven.segal.lawman";
-        String seasonNumString = "1";
-        String episodeNumString = "01";
-
-        String filename = filenameShow + "." + seasonNumString + "."
-            + episodeNumString + ".avi";
-        Path path = ourTempDir.resolve(filename);
-        createFile(path);
-
-        FileEpisode episode = new FileEpisode(path);
-        episode.setFilenameShow(filenameShow);
-        episode.setFilenameSeason(seasonNumString);
-        episode.setFilenameEpisode(episodeNumString);
-
-        String showName = "Steven Seagal: Lawman";
-        Show show = new Show("126841", showName, "http://thetvdb.com/?tab=series&id=126841&lid=7");
-        show.preferProductionOrdering();
-        ShowStore.addShow(filenameShow, show);
-
-        String title = "The Way of the Gun";
-        EpisodeInfo info = new EpisodeInfo.Builder()
-            .episodeId("1111")
-            .seasonNumber(seasonNumString)
-            .episodeNumber(episodeNumString)
-            .episodeName(title)
-            .build();
-        EpisodeInfo[] dummyArray = new EpisodeInfo[1];
-        dummyArray[0] = info;
-        show.addEpisodes(dummyArray);
-        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
-
-        String newFilename = episode.getReplacementText();
-        assertFalse("Resulting filename must not contain a ':' as it breaks Windows",
-                    newFilename.contains(":"));
-    }
-
-    /**
-     * Helper method to physically create the file and add to file list for later deletion.
-     */
-    private void createFile(Path path) throws IOException {
+        Path path = ourTempDir.resolve(data.inputFilename);
         Files.createFile(path);
         testFiles.add(path);
+
+        FileEpisode episode = new FileEpisode(path);
+        episode.setFilenameShow(data.filenameShow);
+        episode.setFilenameSeason(data.seasonNumString);
+        episode.setFilenameEpisode(data.episodeNumString);
+        episode.setFilenameResolution(data.episodeResolution);
+
+        Show show = new Show(data.showId, data.properShowName,
+                             "http://thetvdb.com/?tab=series&id=" + data.showId);
+        show.preferProductionOrdering();
+        ShowStore.addShow(data.filenameShow, show);
+
+        EpisodeInfo info = new EpisodeInfo.Builder()
+            .episodeId(data.episodeId)
+            .seasonNumber(data.seasonNumString)
+            .episodeNumber(data.episodeNumString)
+            .episodeName(data.episodeTitle)
+            .build();
+        EpisodeInfo[] dummyArray = new EpisodeInfo[1];
+        dummyArray[0] = info;
+        show.addEpisodes(dummyArray);
+
+        episode.setStatus(EpisodeStatus.GOT_LISTINGS);
+
+        return episode.getReplacementText();
+    }
+
+    @Test
+    public void testGetReplacementText() {
+        for (EpisodeTestData data : values ) {
+            try {
+                String replacement = getReplacementFilename(data);
+                assertEquals(data.expectedReplacement, replacement);
+            } catch (Exception e) {
+                fail("testing " + data + ": " + e.getMessage());
+                e.printStackTrace();
+            }
+        }
     }
 
     @After

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -2,13 +2,11 @@ package org.tvrenamer.model;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.mockito.Mockito.mock;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import org.tvrenamer.controller.ShowInformationListener;
 import org.tvrenamer.controller.util.FileUtilities;
 
 import java.io.IOException;
@@ -28,7 +26,6 @@ public class FileEpisodeTest {
     private List<Path> testFiles;
 
     private UserPreferences prefs;
-    private ShowInformationListener mockListener;
 
     @Before
     public void setUp() throws Exception {
@@ -36,7 +33,6 @@ public class FileEpisodeTest {
         prefs = UserPreferences.getInstance();
         prefs.setMoveEnabled(false);
         prefs.setRenameEnabled(true);
-        mockListener = mock(ShowInformationListener.class);
     }
 
     /**


### PR DESCRIPTION
I took the existing "$pringfield" and "Steven Segal: Lawman" tests, and built a data structure to support them, and then created examples for all the files we test in TVRenamer.

I noticed that running this test was very noisy, so I quieted things down a bit.

I changed the FileEpisode test to create a subdirectory within the temp directory, and create our files within it.  This way we can freely assume that all files within that directory are "ours".  This allows us to check that everything is created and cleaned up properly.

This will be even more helpful when we expand the test to actually rename the files, but I haven't done that yet.