### PR TITLE
For testing, allow creation of FileEpisode with null path.

### DIFF
--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -113,9 +113,28 @@ public class FileEpisode {
     // Initially we create the FileEpisode with nothing more than the path.
     // Other information will flow in.
     public FileEpisode(Path p) {
+        if (p == null) {
+            logger.severe("cannot create FileEpisode with no path.");
+        }
         fileNameString = p.getFileName().toString();
         filenameSuffix = StringUtils.getExtension(fileNameString);
         setPath(p);
+    }
+
+    // Create FileEpisode with no path
+    public FileEpisode() {
+        // We do not provide any way to create a FileEpisode with a null path
+        // via the UI -- why would we?  Ultimately the program is to rename and
+        // move files, and if there's no file, there's no point.  However, that's
+        // not as true for testing.  There's a lot we do with a FileEpisode before
+        // we ever get around to renaming it, and we shouldn't need to create
+        // actual files on the file system just to test the functionality.
+        fileNameString = "";
+        filenameSuffix = "";
+        // now do what setPath() would do
+        exists = false;
+        fileStatus = FileStatus.NO_FILE;
+        fileSize = NO_FILE_SIZE;
     }
 
     public FileEpisode(String filename) {
@@ -212,7 +231,7 @@ public class FileEpisode {
                 fileSize = NO_FILE_SIZE;
             }
         } else {
-            logger.fine("creating FileEpisode for nonexistent path, " + path);
+            logger.warning("creating FileEpisode for nonexistent path, " + path);
             exists = false;
             fileStatus = FileStatus.NO_FILE;
             fileSize = NO_FILE_SIZE;


### PR DESCRIPTION
Generally, it doesn't make sense to have a FileEpisode with a null path, or with a path to a nonexistent file.  The whole point of the program is to operate on files.  But we do a lot of processing that is not actually based on having a file on disk, and for testing this functionality, we shouldn't need to actually create files.

This commit adds a zero-arg constructor to FileEpisode.  It is public, but it is only intended for testing.  It could be protected/hidden better, if there is any concern about its misuse.