### PR TITLE
Set removeEmptiedDirectories to false.

### DIFF
--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -83,7 +83,7 @@ public class UserPreferences extends Observable {
         seasonPrefixLeadingZero = false;
         moveEnabled = false;
         renameEnabled = true;
-        removeEmptiedDirectories = true;
+        removeEmptiedDirectories = false;
         renameReplacementMask = DEFAULT_REPLACEMENT_MASK;
         proxy = new ProxySettings();
         checkForUpdates = true;


### PR DESCRIPTION
When we move files from a source to destination directory, if the file was the last one in the source directory, and the move renders it empty, we could delete the now-empty directory.  And, if that directory was the last thing in its directory, we could delete the parent, and so on, until we hit a non-empty directory.

The program has the ability to do that, and its controlled by the variable "removeEmptiedDirectories" in UserPreferences.java, which means it's also exposed as a preference with that name.  In fact, if you edit ~/.tvrenamer/prefs.xml, you can successfully set the value of this variable and modify the behavior of the program.

Since the old behavior was to leave the directories as-is, make that the default behavior.

We have not added anything to the UI to allow users to control this, yet.  Again, it works if you edit prefs.xml by hand, but there's no friendlier way to change it yet.