### PR TITLE
Remove unused interface.

### DIFF
--- a/src/main/org/tvrenamer/view/ProgressProxy.java
+++ b/src/main/org/tvrenamer/view/ProgressProxy.java
@@ -1,5 +1,0 @@
-package org.tvrenamer.view;
-
-public interface ProgressProxy {
-    void setProgress(float progress);
-}


### PR DESCRIPTION
This became unused when we reworked FileMover, but I neglected to remove the file at the time.