### PR TITLE
Eliminate special block for DnD IllegalArgument

### DIFF
--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -118,8 +118,6 @@ public class Constants {
         + "and not to rename them, either.  Therefore, there's no action to be taken.  "
         + "Open the Preferences dialog and enable \"Move\", \"Rename\", or both, in order "
         + "to take some action.";
-    public static final String NO_DND = "Drag and Drop is not currently supported "
-        + "on your operating system, please use the 'Browse Files' option above";
     public static final String UNKNOWN_EXCEPTION = "An error occurred, please check "
         + "the console output to see any errors:";
 

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -73,8 +73,6 @@ import java.util.Queue;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.swing.JOptionPane;
-
 public class UIStarter implements Observer,  AddEpisodeListener {
     private static Logger logger = Logger.getLogger(UIStarter.class.getName());
     private static final int SELECTED_COLUMN = 0;
@@ -602,12 +600,8 @@ public class UIStarter implements Observer,  AddEpisodeListener {
                 }
             }
             return 0;
-        } catch (IllegalArgumentException argumentException) {
-            logger.log(Level.SEVERE, NO_DND, argumentException);
-            JOptionPane.showMessageDialog(null, NO_DND);
-            return 1;
         } catch (Exception exception) {
-            showMessageBox(SWTMessageBoxType.ERROR, "Error", UNKNOWN_EXCEPTION, exception);
+            showMessageBox(SWTMessageBoxType.ERROR, ERROR_LABEL, UNKNOWN_EXCEPTION, exception);
             logger.log(Level.SEVERE, UNKNOWN_EXCEPTION, exception);
             return 1;
         }


### PR DESCRIPTION
There was code in UIStarter.java, in the top-level loop, which catches an IllegalArgumentException and warns the user that Drag and Drop is not supported.

We don't really recall the history of this, but it doesn't seem ideal to assume an IllegalArgumentException is due to Drag-and-Drop.  Simply eliminate this block, and now any IllegalArgumentException will fall through to the code immediately following it which catches a generic exception.

Issue #196 