### PR TITLE
Set FileEpisode season and episode strings.

### DIFF
--- a/src/main/org/tvrenamer/controller/TVRenamer.java
+++ b/src/main/org/tvrenamer/controller/TVRenamer.java
@@ -65,8 +65,8 @@ public class TVRenamer {
                 String foundName = matcher.group(1);
                 ShowName.lookupShowName(foundName);
                 episode.setFilenameShow(foundName);
-                episode.setSeasonNum(Integer.parseInt(matcher.group(2)));
-                episode.setEpisodeNum(Integer.parseInt(matcher.group(3)));
+                episode.setFilenameSeason(matcher.group(2));
+                episode.setFilenameEpisode(matcher.group(3));
                 episode.setFilenameResolution(resolution);
                 episode.setParsed();
 


### PR DESCRIPTION
Obviously the primary thing we want to do with "season number" and "episode number" information is treat those values as integers and use them to index into the show's list of episodes to get information about the matching episode.

But, particularly since the indices are not always right, we want to maintain the actual Strings that we extract from the filename.  We have had attributes of FileEpisode to store this information: filenameSeason and filenameEpisode (whereas the equivalent integer values are called seasonNum and episodeNum).  So, instead of having TVRenamer parse the season and episode information, send the actual strings to the FileEpisode, and let it parse them, in addition to storing them.