### PR TITLE
Reinstate thetvdb.com tests.

### DIFF
--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -853,7 +853,7 @@ public class TheTVDBProviderTest {
         }
     }
 
-    // @Test
+    @Test
     public void testGetEpisodeTitle() {
         for (EpisodeTestData testInput : values) {
             if (testInput.episodeTitle != null) {


### PR DESCRIPTION
These tests depend on the provider being up and responsive and providing consistent data, they cause unnecessary traffic to an overloaded web site, and they take a long time.  For those reasons, I disabled them a while ago.  But as we get close to a release point, maybe it makes sense to have as many tests as possible.  Even though we can get false negatives from this test, in practice it is pretty good, as long as you don't mind waiting for it.