### PR TITLE
Modify when we ensure the destination directory.

### DIFF
--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -104,6 +104,7 @@ public class Constants {
     public static final String RENAME_FORMAT_TOOLTIP = "The result of the rename, with the "
         + "tokens being replaced by the meaning above";
     public static final String CANT_CREATE_DEST = "Unable to create the destination directory";
+    public static final String MOVE_NOW_DISABLED = "Move is now disabled.";
     public static final String MOVE_INTRO = "Clicking this button will ";
     public static final String AND_RENAME = "rename and ";
     public static final String INTRO_MOVE_DIR = "move the selected files to the directory "

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -36,12 +36,9 @@ import org.eclipse.swt.widgets.TabItem;
 import org.eclipse.swt.widgets.Text;
 
 import org.tvrenamer.model.ReplacementToken;
-import org.tvrenamer.model.SWTMessageBoxType;
-import org.tvrenamer.model.TVRenamerIOException;
 import org.tvrenamer.model.UserPreferences;
 
 import java.util.Arrays;
-import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -405,14 +402,10 @@ public class PreferencesDialog extends Dialog {
 
         prefs.setCheckForUpdates(checkForUpdatesCheckbox.getSelection());
         prefs.setRecursivelyAddFolders(recurseFoldersCheckbox.getSelection());
+        prefs.setDestinationDirectory(destDirText.getText());
 
-        try {
-            prefs.setDestinationDirectory(destDirText.getText());
-        } catch (TVRenamerIOException e) {
-            UIUtils.showMessageBox(SWTMessageBoxType.ERROR, ERROR_LABEL, CANT_CREATE_DEST + ": "
-                + destDirText.getText());
-            logger.log(Level.WARNING, CANT_CREATE_DEST, e);
-        }
+        UIUtils.checkDestinationDirectory(prefs);
+
         UserPreferences.store(prefs);
     }
 

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -114,6 +114,7 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
 
         // Setup the util class
         UIUtils.setShell(shell);
+        UIUtils.checkDestinationDirectory(prefs);
 
         // Add controls to main shell
         setupMainWindow();
@@ -885,6 +886,10 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
 
         if (upref == UserPreference.IGNORE_REGEX) {
             ignoreKeywords = observed.getIgnoreKeywords();
+        }
+
+        if (upref == UserPreference.DEST_DIR) {
+            UIUtils.checkDestinationDirectory(observed);
         }
     }
 

--- a/src/main/org/tvrenamer/view/UIUtils.java
+++ b/src/main/org/tvrenamer/view/UIUtils.java
@@ -1,11 +1,14 @@
 package org.tvrenamer.view;
 
+import static org.tvrenamer.model.util.Constants.*;
+
 import org.eclipse.swt.graphics.FontData;
 import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.MessageBox;
 import org.eclipse.swt.widgets.Shell;
 
 import org.tvrenamer.model.SWTMessageBoxType;
+import org.tvrenamer.model.UserPreferences;
 
 import java.awt.HeadlessException;
 import java.util.logging.Level;
@@ -95,5 +98,14 @@ public class UIUtils {
             + "\nNote that proxies are not currently supported.";
         logger.log(Level.WARNING, message, exception);
         showMessageBox(SWTMessageBoxType.ERROR, "Error", message);
+    }
+
+    public static void checkDestinationDirectory(UserPreferences prefs) {
+        boolean success = prefs.ensureDestDir();
+        if (!success) {
+            logger.warning(CANT_CREATE_DEST);
+            showMessageBox(SWTMessageBoxType.ERROR, ERROR_LABEL, CANT_CREATE_DEST + ": '"
+                           + prefs.getDestinationDirectoryName() + "'. " + MOVE_NOW_DISABLED);
+        }
     }
 }


### PR DESCRIPTION
One thing that motivated this change is, if you have a bad destination directory in your preferences, and move enabled, and you try to run the unit tests, it used to pop up a dialog box to tell you about the bad directory.

That obviously wouldn't affect normal users, but we do want to have a command-line version at some point in the near future, and it would affect them then.

Besides that, being able to put up that dialog box required a lot more interreliance between the view and model packages, than we'd like.

I also think we might have been checking the directory more often than is useful.  So the changes here are:

- don't bother ensuring the destination directory when the UserPreferences are loaded or instantiated
- don't use exceptions to communicate the lack of directory
- new static method in UIUtils to check the directory and generate a dialog box if it can't be created
  - since it's a static method, the instance of UserPreferences must be provided
- don't have code in PreferencesDialog that would directly generate a dialog box
  - rely on new UIUtils method, instead
- check the destination directory in UIStarter.init(); this obviously only runs when the UI is starting up
  - this makes it a safe place to generate a dialog box
- don't ensure inside UserPreferences.setDestinationDirectory()
  - although it's true this is a great time to check the destination directory, that doesn't mean the setter has to do it
  - when the destination directory is changed, a notification is generated
  - UIStarter subscribes to these notifications
  - when it gets a notification that the destination directory has changed, it runs the UIUtils method again

In addition to the behavioral changes, this also means that UserPreferences no longer has any dependency on the view package, and PreferencesDialog loses half of its dependencies in the model package.

When we add a command-line version, some other class should do what UIStarter does, in a nongraphical way: check the directory at startup, and again any time it changes, by subscribing to notifications from UserPreferences.

The same is likely true whe we add unit tests that actually move files to a destination directory, but currently we don't have any unit tests like that.