### PR TITLE
Move comment block to refer to class.

### DIFF
--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -1,3 +1,9 @@
+package org.tvrenamer.model.util;
+
+import java.nio.charset.Charset;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * Constants.java -- the most important reason for this class to exist is for pieces of
  *    information that are shared throughout the program, so that if they should ever
@@ -23,13 +29,6 @@
  * inlined strings to resource files.  This just makes it easier to do it incrementally.
  *
  */
-
-package org.tvrenamer.model.util;
-
-import java.nio.charset.Charset;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-
 public class Constants {
 
     public static final Charset TVR_CHARSET = Charset.forName("ISO-8859-1");


### PR DESCRIPTION
Having a block comment at the very top of a file, before "package" and "imports", does not tell javadoc that the comment refers to the class.