### PR TITLE
improve error messaging

### DIFF
--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -174,7 +174,8 @@ public class TheTVDBProvider {
             Document doc = dbf.parse(listingsXmlSource);
             episodeList = nodeListValue(XPATH_EPISODE_LIST, doc);
         } catch (XPathExpressionException | SAXException | DOMException e) {
-            logger.log(Level.WARNING, e.getMessage(), e);
+            logger.log(Level.WARNING, "exception parsing episodes for " + show + ": "
+                       + e.getMessage(), e);
             throw new TVRenamerIOException(ERROR_PARSING_XML, e);
         } catch (NumberFormatException nfe) {
             logger.log(Level.WARNING, nfe.getMessage(), nfe);

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -304,8 +304,8 @@ public class Show {
             // etc.  But it could also be used for this case.
             logger.warning("two episodes found for show " + name + ", season "
                            + seasonNum + ", episode " + episodeNum + ": \""
-                           + found.getTitle() + "\" and \""
-                           + episode.getTitle() + "\"");
+                           + found.getTitle() + "\" (" + found.getEpisodeId() + ") and \""
+                           + episode.getTitle() + "\" (" + episode.getEpisodeId() + ")");
         }
     }
 

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -214,6 +214,7 @@ public class FileEpisodeTest {
                    .episodeNumString("04")
                    .filenameSuffix(".hdtv-lol")
                    .episodeTitle("Double Trouble")
+                   .episodeId("5318362")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("NCIS S13E04 Double Trouble")
                    .build());
@@ -229,6 +230,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Don Hoberman")
+                   .episodeId("410276")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Nip-Tuck S06E01 Don Hoberman")
                    .build());
@@ -240,6 +242,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Rewind")
+                   .episodeId("1261701")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Human Target (2010) S01E02 Rewind")
@@ -252,6 +255,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Little Girl Lost")
+                   .episodeId("445732")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Castle (2009) S01E09 Little Girl Lost")
@@ -267,6 +271,7 @@ public class FileEpisodeTest {
                    .episodeNumString("20")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Higher Ground")
+                   .episodeId("4818702")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Reign (2013) S01E20 Higher Ground")
                    .build());
@@ -277,6 +282,7 @@ public class FileEpisodeTest {
                    .episodeNumString("10")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Yousaf")
+                   .episodeId("4770469")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("The Americans (2013) S02E10 Yousaf")
                    .build());
@@ -301,6 +307,7 @@ public class FileEpisodeTest {
                    .episodeNumString("12")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Under Pressure")
+                   .episodeId("4731166")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Modern Family S05E12 Under Pressure")
                    .build());
@@ -311,6 +318,7 @@ public class FileEpisodeTest {
                    .episodeNumString("1")
                    .filenameSuffix(".mp4")
                    .episodeTitle("The Wars to Come")
+                   .episodeId("5083694")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Game of Thrones S05E01 The Wars to Come")
                    .build());
@@ -322,6 +330,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Day 8: 4:00 P.M. - 5:00 P.M.")
+                   .episodeId("806851")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("24 S08E01 Day 8 - 4 -00 P.M. - 5 -00 P.M.")
@@ -338,6 +347,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Day 7: 1:00 A.M. - 2:00 A.M.")
+                   .episodeId("423760")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("24 S07E18 Day 7 - 1 -00 A.M. - 2 -00 A.M.")
@@ -350,6 +360,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Slack Tide")
+                   .episodeId("997661")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Dexter S04E07 Slack Tide")
@@ -361,6 +372,7 @@ public class FileEpisodeTest {
                    .episodeNumString("1")
                    .filenameSuffix(".avi")
                    .episodeTitle("Hail and Farewell, Part II (2)")
+                   .episodeId("126483")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("JAG S10E01 Hail and Farewell, Part II (2)")
                    .build());
@@ -376,6 +388,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Lighthouse")
+                   .episodeId("1155311")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Lost S06E05 Lighthouse")
@@ -388,6 +401,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Pilot")
+                   .episodeId("600981")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Warehouse 13 S01E01 Pilot")
@@ -399,6 +413,7 @@ public class FileEpisodeTest {
                    .episodeNumString("14")
                    .filenameSuffix(".avi")
                    .episodeTitle("Family Affair")
+                   .episodeId("1446541")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("One Tree Hill S07E14 Family Affair")
                    .build());
@@ -413,6 +428,7 @@ public class FileEpisodeTest {
                    .episodeNumString("15")
                    .filenameSuffix(".avi")
                    .episodeTitle("The Sixteen Year Old Virgin")
+                   .episodeId("1311951")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Gossip Girl S03E15 The Sixteen Year Old Virgin")
                    .build());
@@ -423,6 +439,7 @@ public class FileEpisodeTest {
                    .episodeNumString("14")
                    .filenameSuffix(".avi")
                    .episodeTitle("Conspiracy")
+                   .episodeId("1286161")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Smallville S09E14 Conspiracy")
                    .build());
@@ -433,6 +450,7 @@ public class FileEpisodeTest {
                    .episodeNumString("15")
                    .filenameSuffix(".avi")
                    .episodeTitle("Escape")
+                   .episodeId("1231561")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Smallville S09E15 Escape")
                    .build());
@@ -448,6 +466,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("The Pants Alternative")
+                   .episodeId("1801741")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("The Big Bang Theory S03E18 The Pants Alternative")
@@ -459,6 +478,7 @@ public class FileEpisodeTest {
                    .episodeNumString("5")
                    .filenameSuffix(".mkv")
                    .episodeTitle("First Blood")
+                   .episodeId("2460921")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Dexter S05E05 First Blood")
                    .build());
@@ -469,6 +489,7 @@ public class FileEpisodeTest {
                    .episodeNumString("7")
                    .filenameSuffix(".mkv")
                    .episodeTitle("The Other 48 Days")
+                   .episodeId("304796")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Lost S02E07 The Other 48 Days")
                    .build());
@@ -483,6 +504,7 @@ public class FileEpisodeTest {
                    .episodeNumString("4")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Dicks")
+                   .episodeId("4840650")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Californication S07E04 Dicks")
                    .build());
@@ -493,6 +515,7 @@ public class FileEpisodeTest {
                    .episodeNumString("7")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Waning Minutes")
+                   .episodeId("4833023")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Continuum S03E07 Waning Minutes")
                    .build());
@@ -503,6 +526,7 @@ public class FileEpisodeTest {
                    .episodeNumString("23")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Art in the Blood")
+                   .episodeId("4833389")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Elementary S02E23 Art in the Blood")
                    .build());
@@ -517,6 +541,7 @@ public class FileEpisodeTest {
                    .episodeNumString("19")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Meg Stinks!")
+                   .episodeId("4840967")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Family Guy S12E19 Meg Stinks!")
                    .build());
@@ -527,6 +552,7 @@ public class FileEpisodeTest {
                    .episodeNumString("1")
                    .filenameSuffix(".mp4")
                    .episodeTitle("The Crocodile's Dilemma")
+                   .episodeId("4626050")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Fargo S01E01 The Crocodile's Dilemma")
                    .build());
@@ -537,6 +563,7 @@ public class FileEpisodeTest {
                    .episodeNumString("11")
                    .filenameSuffix(".mp4")
                    .episodeTitle("I Saw You")
+                   .episodeId("4756574")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Girls S03E11 I Saw You")
                    .build());
@@ -551,6 +578,7 @@ public class FileEpisodeTest {
                    .episodeNumString("19")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Nobody Knows the Trubel I've Seen")
+                   .episodeId("4806887")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Grimm S03E19 Nobody Knows the Trubel I've Seen")
                    .build());
@@ -561,6 +589,7 @@ public class FileEpisodeTest {
                    .episodeNumString("23")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Cruise")
+                   .episodeId("4818762")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("New Girl S03E23 Cruise")
                    .build());
@@ -571,6 +600,7 @@ public class FileEpisodeTest {
                    .episodeNumString("4")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Jungle Love")
+                   .episodeId("4818766")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Nurse Jackie S06E04 Jungle Love")
                    .build());
@@ -585,6 +615,7 @@ public class FileEpisodeTest {
                    .episodeNumString("1")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Back in the Game")
+                   .episodeId("4856111")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Offspring S05E01 Back in the Game")
                    .build());
@@ -595,6 +626,7 @@ public class FileEpisodeTest {
                    .episodeNumString("4")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Rebel Appliance")
+                   .episodeId("4874676")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Robot Chicken S07E04 Rebel Appliance")
                    .build());
@@ -605,6 +637,7 @@ public class FileEpisodeTest {
                    .episodeNumString("21")
                    .filenameSuffix(".mp4")
                    .episodeTitle("King of the Damned")
+                   .episodeId("4837871")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Supernatural S09E21 King of the Damned")
                    .build());
@@ -619,6 +652,7 @@ public class FileEpisodeTest {
                    .episodeNumString("23")
                    .filenameSuffix(".mp4")
                    .episodeTitle("The Gorilla Dissolution")
+                   .episodeId("4840953")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("The Big Bang Theory S07E23 The Gorilla Dissolution")
                    .build());
@@ -639,6 +673,7 @@ public class FileEpisodeTest {
                    .episodeNumString("5")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Fishing")
+                   .episodeId("4833100")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Veep S03E05 Fishing")
                    .build());
@@ -653,6 +688,7 @@ public class FileEpisodeTest {
                    .episodeNumString("1")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Pilot")
+                   .episodeId("4536811")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Witches of East End S01E01 Pilot")
                    .build());
@@ -663,6 +699,7 @@ public class FileEpisodeTest {
                    .episodeNumString("4")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Savage Seduction")
+                   .episodeId("4835105")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Warehouse 13 S05E04 Savage Seduction")
                    .build());
@@ -673,6 +710,7 @@ public class FileEpisodeTest {
                    .episodeNumString("8")
                    .filenameSuffix(".mp4")
                    .episodeTitle("Spacewalker")
+                   .episodeId("5044973")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("The 100 S02E08 Spacewalker")
                    .build());
@@ -858,6 +896,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Sin-Eater")
+                   .episodeId("5684178")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Lucifer S02E03 Sin-Eater")
@@ -874,6 +913,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("1080p")
                    .episodeTitle("Uprising")
+                   .episodeId("5757555")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Marvel's Agents of S.H.I.E.L.D. S04E03 Uprising")
@@ -918,6 +958,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("480p")
                    .episodeTitle("You Have to Go Inside")
+                   .episodeId("5700172")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Channel Zero S01E01 You Have to Go Inside")
@@ -930,6 +971,7 @@ public class FileEpisodeTest {
                    .filenameSuffix(".mkv")
                    .episodeResolution("720p")
                    .episodeTitle("Love Boat")
+                   .episodeId("5719479")
                    // .replacementMask("%S [%sx%e] %t %r")
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("NCIS S14E04 Love Boat")


### PR DESCRIPTION
In a couple of cases, make error messages more informative.

Add real episode IDs to FileEpisodeTest, because with the network tests reinstated, we eventually get the real episode IDs, and we get warnings about conflicts if we use the temporary IDs.