### PR TITLE
Reinstate most TVDB tests

### DIFF
--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -483,8 +483,8 @@ public class TheTVDBProviderTest {
 
     // @BeforeClass
     public static void setupValues36() {
-        // Comment this out because trying options for "the walking dead"
-        // include a "Series Not Permitted"
+        // Trying options for "the walking dead" gives a "Series Not Permitted".
+        // We issue a warning, but it's not really a problem.
         values.add(new EpisodeTestData.Builder()
                    .queryString("the walking dead")
                    .seasonNum(4)

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -405,8 +405,10 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    @BeforeClass
+    // @BeforeClass
     public static void setupValues29() {
+        // Comment this out because Offspring has three untitled episodes with
+        // the same season and episode, but different IDs
         values.add(new EpisodeTestData.Builder()
                    .queryString("offspring")
                    .seasonNum(5)
@@ -425,8 +427,10 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    @BeforeClass
+    // @BeforeClass
     public static void setupValues31() {
+        // Comment this out because Robot Chicken has a conflict between DVD
+        // and regular numbering.
         values.add(new EpisodeTestData.Builder()
                    .queryString("robot chicken")
                    .seasonNum(7)
@@ -465,8 +469,10 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    @BeforeClass
+    // @BeforeClass
     public static void setupValues35() {
+        // Comment this out because the episode listing for The Good Wife
+        // currently (2017/06/02) comes through unparseable.
         values.add(new EpisodeTestData.Builder()
                    .queryString("the good wife")
                    .seasonNum(5)
@@ -475,8 +481,10 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    @BeforeClass
+    // @BeforeClass
     public static void setupValues36() {
+        // Comment this out because trying options for "the walking dead"
+        // include a "Series Not Permitted"
         values.add(new EpisodeTestData.Builder()
                    .queryString("the walking dead")
                    .seasonNum(4)
@@ -665,8 +673,10 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    @BeforeClass
+    // @BeforeClass
     public static void setupValues55() {
+        // Comment this out because "strike back" apparently no longer
+        // resolves to the correct show.
         values.add(new EpisodeTestData.Builder()
                    .queryString("strike back")
                    .seasonNum(1)
@@ -735,8 +745,10 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    @BeforeClass
+    // @BeforeClass
     public static void setupValues62() {
+        // Comment this out because "Lucifer" has conflicting special episodes
+        // (season "0", episode "2")
         values.add(new EpisodeTestData.Builder()
                    .queryString("lucifer")
                    .seasonNum(2)
@@ -837,7 +849,7 @@ public class TheTVDBProviderTest {
         }
     }
 
-    // @Test
+    @Test
     public void testGetEpisodeTitle() {
         for (EpisodeTestData testInput : values) {
             if (testInput.episodeTitle != null) {


### PR DESCRIPTION
These tests depend on the provider being up and responsive and providing consistent data, they cause unnecessary traffic to an overloaded web site, and they take a long time.  For those reasons, I disabled them a while ago.  But to verify the v1 API is still working, maybe it makes sense to have as many tests as possible.  Even though we can get false negatives from this test, in practice it is pretty good, as long as you don't mind waiting for it.

I did, however, comment out several of the tests.  Two of them were failing:
 - "strike back" apparently no longer resolves to the right show
 - "The Good Wife" is currently returning unparsable XML

The other tests I commented out were passing, but the shows had warnings.  To get clean output, remove these tests.  I added comments for each test I commented out.