### PR TITLE
detect deprecated API, and other improvements

### DIFF
--- a/etc/run-scripts/conflicts.sh
+++ b/etc/run-scripts/conflicts.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+srcdir=~/Documents/VC/tvrenamer
+
+indir=~/Desktop/Videos/testdir/intest
+outdir=~/Desktop/Videos/testdir/outtest
+runprog=run-mingw.sh
+
+if [ "`uname`" = "Darwin" ]
+then
+  indir=~/Movies/intest
+  outdir=~/Movies/outtest
+  runprog=run-osx.sh
+fi
+
+testtoo=no
+
+if [ "$1" = "-test" ]
+then
+  testtoo=yes
+fi
+
+/bin/rm -rf ${indir}
+/bin/rm -rf ${outdir}
+
+/bin/mkdir -p ${indir}
+echo contents > ${indir}/Dilbert.S01E09.The.Knack.avi
+echo contents > ${indir}/Futurama.S07E01.The.Bots.and.the.Bees.avi
+echo contents > ${indir}/Transparent.S02E08.Oscillate.mp4
+
+# Add a test to demonstrate "no such show" functionality
+echo contents > ${indir}/Zygostatical.S01E22.mp4
+
+/bin/mkdir ${indir}/Frasier
+echo contents > ${indir}/Frasier/S10E01.The.Ring.Cycle.avi
+echo contents > ${indir}/Frasier/Frasier.S10E01.dvdrip.avi
+/bin/mkdir ${indir}/Veep
+echo contents1234 > ${indir}/Veep.S04E07.Mommy.Meyer.~6.mp4
+echo contents12345 > ${indir}/Veep/Veep.S04E07.Mommy.Meyer.mp4
+echo contents123 > ${indir}/Veep/Veep.S04E07.Mommy.Meyer.~2.mp4
+echo contents123456 > ${indir}/Veep/Veep.S04E07.Mommy.Meyer.~4.mp4
+echo contents > ${indir}/Veep/Veep.S04E07.Mommy.Meyer.~5.mp4
+echo contents1 > ${indir}/Veep/Veep.S04E07.Mommy.Meyer.~7.mp4
+echo contents12 > ${indir}/Veep/Veep.S04E07.Mommy.Meyer.~11.mp4
+
+cd ${srcdir}
+
+if [ "${testtoo}" = "yes" ]
+then
+  ant test&
+fi
+
+./etc/run-scripts/${runprog} -build || exit 1
+
+echo
+echo '** indir'
+/bin/ls -lR ${indir}
+
+echo
+echo '** outdir'
+/bin/ls -lR ${outdir}

--- a/etc/run-scripts/run-mingw.sh
+++ b/etc/run-scripts/run-mingw.sh
@@ -36,6 +36,12 @@ windowsize ()
   echo $1 | sed 's,^/\([a-zA-Z]\)/,\1:/,'
 }
 
+# To go in the other direction, we do need to change the slashes.
+unixize ()
+{
+  echo $1 | sed 's,^\([a-zA-Z]\):,/\1,' | tr '\\' '/'
+}
+
 usage ()
 {
   echo "Error: unrecognized argument $1"
@@ -47,16 +53,22 @@ usage ()
 # to come back to it.
 startdir=`pwd`
 
+userhome=${HOME}
+if [ -n "${USERPROFILE}" ]
+then
+  userhome=`unixize ${USERPROFILE}`
+fi
+
 # If the configuration is in the older style, transform it.
 # This actually is also done by the UserPreferences class, but simpler to
 # take care of it here, beforehand.
-if [ ! -d ~/.tvrenamer ]
+if [ ! -d ${userhome}/.tvrenamer ]
 then
-  if [ -f ~/.tvrenamer ]
+  if [ -f ${userhome}/.tvrenamer ]
   then
-    /bin/mv ~/.tvrenamer ~/prefs.xml
-    /bin/mkdir ~/.tvrenamer
-    /bin/mv ~/prefs.xml ~/.tvrenamer/prefs.xml
+    /bin/mv ${userhome}/.tvrenamer ${userhome}/prefs.xml
+    /bin/mkdir ${userhome}/.tvrenamer
+    /bin/mv ${userhome}/prefs.xml ${userhome}/.tvrenamer/prefs.xml
   fi
 fi
 
@@ -71,13 +83,7 @@ then
   if [ "$1" = "-build" ]
   then
     shift
-    if [ -n "$1" ]
-    then
-      usage $1
-    fi
     ant compile || exit 2
-  else
-    usage $1
   fi
 fi
 
@@ -94,4 +100,4 @@ do
 done
 export CLASSPATH
 
-java org.tvrenamer.controller.Launcher
+java org.tvrenamer.controller.Launcher $*

--- a/etc/run-scripts/run-osx.sh
+++ b/etc/run-scripts/run-osx.sh
@@ -42,13 +42,7 @@ then
   if [ "$1" = "-build" ]
   then
     shift
-    if [ -n "$1" ]
-    then
-      usage $1
-    fi
     ant compile || exit 2
-  else
-    usage $1
   fi
 fi
 
@@ -65,4 +59,4 @@ do
 done
 export CLASSPATH
 
-java -XstartOnFirstThread org.tvrenamer.controller.Launcher
+java -XstartOnFirstThread org.tvrenamer.controller.Launcher $*

--- a/etc/run-scripts/tvrtest.sh
+++ b/etc/run-scripts/tvrtest.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+prefs=~/.tvrenamer/prefs.xml
+
+srcdir=~/Documents/VC/tvrenamer
+
+indir=~/Desktop/Videos/testdir/intest
+outdir=~/Desktop/Videos/testdir/outtest
+runprog=run-mingw.sh
+
+if [ "`uname`" = "Darwin" ]
+then
+  indir=~/Movies/intest
+  outdir=~/Movies/outtest
+  runprog=run-osx.sh
+fi
+
+clean=no
+testtoo=no
+swap=no
+
+if [ "$1" = "-test" ]
+then
+  testtoo=yes
+fi
+
+if [ "${swap}" = "yes" ]
+then
+  sed 's,destDir,tempname,g' ${prefs} > ~/x
+  sed 's,preloadFolder,destDir,g' ~/x > ~/y
+  sed 's,tempname,preloadFolder,g' ~/y > ${prefs}
+  /bin/rm ~/x ~/y
+fi
+
+/bin/rm -rf ${indir}
+/bin/rm -rf ${outdir}
+
+decache ()
+{
+  if [ -n "$1" ]
+  then
+    cf=~/.tvrenamer/thetvdb/${1}.xml
+    echo $cf
+    /bin/rm -f $cf
+  fi
+}
+
+# decache veep
+# decache 237831
+
+if [ "${clean}" = "yes" ]
+then
+  decache bewitched
+  decache dilbert
+  decache frasier
+  decache friends
+  decache futurama
+  decache glee
+  decache mom
+  decache seinfeld
+  decache transparent
+  decache 71528
+  decache 94571
+  decache 78581
+  decache 77811
+  decache 79168
+  decache 73871
+  decache 83610
+  decache 266967
+  decache 79169
+  decache 278334
+fi
+
+/bin/mkdir -p ${indir}
+echo contents > ${indir}/Bewitched.S05E02.Samantha.Goes.South.for.a.Spell.avi
+echo contents > ${indir}/Dilbert.S01E09.The.Knack.avi
+echo contents > ${indir}/Frasier.S10E01.The.Ring.Cycle.mp4
+echo contents > ${indir}/Frasier.S10E01.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E02.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E03.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E05.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E08.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E09.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E10.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E11.dvdrip.avi
+echo contents > ${indir}/Frasier.S10E12.dvdrip.avi
+echo contents > ${indir}/Friends.S09E01.The.One.Where.No.One.Proposes.avi
+echo contents > ${indir}/Glee.S06E07.Transitioning.m4v
+echo contents > ${indir}/Mom.S03E11.Cinderella.and.a.Drunk.MacGyver.mp4
+echo contents > ${indir}/Seinfeld.S08E01.The.Foundation.mkv
+echo contents > ${indir}/Transparent.S02E08.Oscillate.mp4
+echo contents > ${indir}/Veep.S04E07.Mommy.Meyer.mp4
+
+/bin/mkdir ${indir}/Futurama
+echo contents > ${indir}/Futurama/S01E07.My.Three.Suns.avi
+
+# Seem to be having a problem with this show.  To be investigated...
+# decache community
+# echo contents > ${indir}/Community.S04E11.Basic.Human.Anatomy.mkv
+
+# This tests an alias, which are not implemented in this branch
+# echo contents > ${indir}/BSG.S04E20.Daybreak.Pt.2.HD.m4v
+
+# /bin/mkdir ${indir}/JohnLarroquetteShow
+# /bin/mkdir "${indir}/JohnLarroquetteShow/Season 3"
+# echo contents > "${indir}/JohnLarroquetteShow/Season 3/3x18 - The Dance.avi"
+
+# echo contents > "${indir}/Beavis.and.Butt-head.S03E11.x264-FLEET.avi"
+# echo contents > ${indir}/MythBusters.2007x14.mpg
+
+/bin/mkdir -p ${outdir}
+/bin/mkdir ${outdir}/Veep
+echo contents > ${outdir}/Veep/Veep.S04E07.Mommy.Meyer.2015.05.24.mp4
+
+cd ${srcdir}
+
+if [ "${testtoo}" = "yes" ]
+then
+  ant test&
+fi
+
+./etc/run-scripts/${runprog} -build || exit 1
+
+echo '** outdir'
+/bin/ls -R ${outdir}
+
+echo '** outdir/Veep'
+/bin/ls ${outdir}/Veep
+
+echo
+echo '** indir'
+/bin/ls -R ${indir}

--- a/src/main/org/tvrenamer/controller/HttpConnectionHandler.java
+++ b/src/main/org/tvrenamer/controller/HttpConnectionHandler.java
@@ -4,6 +4,7 @@ import org.tvrenamer.controller.util.StringUtils;
 import org.tvrenamer.model.TVRenamerIOException;
 
 import java.io.BufferedReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -91,6 +92,15 @@ class HttpConnectionHandler {
                     logger.log(Level.FINEST, "Url stream:\n{0}", contents.toString());
                 }
             }
+        } catch (FileNotFoundException e) {
+            String message = "FileNotFoundException when attempting to download"
+                + " and parse URL " + url;
+            // We don't necessarily consider FileNotFoundException to be "severe".
+            // That's why it's handled first, as a special case.  We create and
+            // throw the TVRenamerIOException in the same way as any other exception;
+            // we just don't log it at the same level.
+            logger.fine(message);
+            throw new TVRenamerIOException(message, e);
         } catch (Exception e) {
             String message = "Exception when attempting to download and parse URL " + url;
             logger.log(Level.SEVERE, message, e);

--- a/src/main/org/tvrenamer/controller/Launcher.java
+++ b/src/main/org/tvrenamer/controller/Launcher.java
@@ -8,11 +8,14 @@ import org.tvrenamer.view.UIStarter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.logging.LogManager;
+import java.util.logging.Logger;
 
 class Launcher {
+    private static final Logger logger = Logger.getLogger(Launcher.class.getName());
 
-    // Static initalisation block
-    static {
+    public static final int DID_NOT_RUN = -99;
+
+    static void initializeLogger() {
         // Find logging.properties file inside jar
         try (InputStream loggingConfigStream
              = Launcher.class.getResourceAsStream(LOGGING_PROPERTIES))
@@ -45,9 +48,24 @@ class Launcher {
      * @param args
      *    not actually processed, at this time
      */
-    public static void main(String[] args) {
+    public static int launchUi(String[] args) {
         UIStarter ui = new UIStarter();
         int status = ui.run();
+        return status;
+    }
+
+    /**
+     * Run a program; currently hard-coded to launchUi(), but can be expanded.
+     *
+     * @param args
+     *    not actually processed, at this time; passed along
+     */
+    public static void main(String[] args) {
+        initializeLogger();
+        int status = DID_NOT_RUN;
+
+        status = launchUi(args);
+
         tvRenamerThreadShutdown();
         System.exit(status);
     }

--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -53,7 +53,6 @@ public class TheTVDBProvider {
     private static final String XPATH_SHOW = "/Data/Series";
     private static final String XPATH_SHOWID = "seriesid";
     private static final String XPATH_NAME = "SeriesName";
-    private static final String XPATH_IMDB = "IMDB_ID";
     private static final String SERIES_NOT_PERMITTED = "** 403: Series Not Permitted **";
 
     // The URL to get, to receive listings for a specific given series.
@@ -136,13 +135,12 @@ public class TheTVDBProvider {
             Node eNode = shows.item(i);
             String seriesName = nodeTextValue(XPATH_NAME, eNode);
             String tvdbId = nodeTextValue(XPATH_SHOWID, eNode);
-            String imdbId = nodeTextValue(XPATH_IMDB, eNode);
 
             if (SERIES_NOT_PERMITTED.equals(seriesName)) {
                 logger.warning("ignoring unpermitted option for "
                                + showName.getFoundName());
             } else {
-                showName.addShowOption(tvdbId, seriesName, imdbId);
+                showName.addShowOption(tvdbId, seriesName);
             }
         }
     }

--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -29,18 +29,31 @@ import javax.xml.xpath.XPathExpressionException;
 public class TheTVDBProvider {
     private static final Logger logger = Logger.getLogger(TheTVDBProvider.class.getName());
 
+    // The unique API key for our application
     private static final String API_KEY = "4A9560FF0B2670B2";
 
-    private static final String BASE_SEARCH_URL = "http://www.thetvdb.com/api/GetSeries.php?seriesname=";
+    // The base information for the provider
+    private static final String DEFAULT_SITE_URL = "http://thetvdb.com/";
+    private static final String API_URL = DEFAULT_SITE_URL + "api/";
+
+    // The URL to get, to receive options for a given series search string.
+    // Note, does not take API key.
+    private static final String BASE_SEARCH_URL = API_URL + "GetSeries.php?seriesname=";
+
+    // These are the tags that we use to extract the relevant information from the show document.
     private static final String XPATH_SHOW = "/Data/Series";
     private static final String XPATH_SHOWID = "seriesid";
     private static final String XPATH_NAME = "SeriesName";
     private static final String XPATH_IMDB = "IMDB_ID";
-    private static final String BASE_LIST_URL = "http://thetvdb.com/api/" + API_KEY + "/series/";
-    private static final String BASE_LIST_FILENAME = "/all/" + DEFAULT_LANGUAGE + XML_SUFFIX;
-    private static final String XPATH_EPISODE_LIST = "/Data/Episode";
     private static final String SERIES_NOT_PERMITTED = "** 403: Series Not Permitted **";
 
+    // The URL to get, to receive listings for a specific given series.
+    private static final String BASE_LIST_URL = API_URL + API_KEY + "/series/";
+    private static final String BASE_LIST_FILENAME = "/all/" + DEFAULT_LANGUAGE + XML_SUFFIX;
+
+    // These are the tags that we use to extract the episode information
+    // from the listings document.
+    private static final String XPATH_EPISODE_LIST = "/Data/Episode";
     private static final String XPATH_EPISODE_ID = "id";
     private static final String XPATH_SEASON_NUM = "SeasonNumber";
     private static final String XPATH_EPISODE_NUM = "EpisodeNumber";
@@ -174,7 +187,8 @@ public class TheTVDBProvider {
             Document doc = dbf.parse(listingsXmlSource);
             episodeList = nodeListValue(XPATH_EPISODE_LIST, doc);
         } catch (XPathExpressionException | SAXException | DOMException e) {
-            logger.log(Level.WARNING, e.getMessage(), e);
+            logger.log(Level.WARNING, "exception parsing episodes for " + show + ": "
+                       + e.getMessage(), e);
             throw new TVRenamerIOException(ERROR_PARSING_XML, e);
         } catch (NumberFormatException nfe) {
             logger.log(Level.WARNING, nfe.getMessage(), nfe);

--- a/src/main/org/tvrenamer/controller/util/StringUtils.java
+++ b/src/main/org/tvrenamer/controller/util/StringUtils.java
@@ -343,6 +343,27 @@ public class StringUtils {
     }
 
     /**
+     * Reverse the effect of encodeSpecialCharacters
+     *
+     * @param input
+     *            string to decode
+     * @return human-friendly representation of input
+     */
+    public static String decodeSpecialCharacters(String input) {
+        if (input == null || input.length() == 0) {
+            return "";
+        }
+
+        input = input.replaceAll("&amp; ", "& ");
+
+        // Don't encode string within xml data strings
+        if (!input.startsWith("<?xml")) {
+            input = input.replaceAll("%20", " ");
+        }
+        return input;
+    }
+
+    /**
      * Compares two strings, considering null equal to null.
      *
      * @param s1

--- a/src/main/org/tvrenamer/model/FailedShow.java
+++ b/src/main/org/tvrenamer/model/FailedShow.java
@@ -1,12 +1,35 @@
 package org.tvrenamer.model;
 
+import org.tvrenamer.controller.TheTVDBProvider;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 class FailedShow extends LocalShow {
 
-    @SuppressWarnings("FieldCanBeLocal")
     private final TVRenamerIOException err;
 
-    public TVRenamerIOException getError() {
-        return err;
+    /**
+     * Find out if the results of querying for this show indicate that the API
+     * is no longer supported.
+     *
+     * @return true if the API is deprecated; false otherwise.
+     */
+    public boolean isApiDeprecated() {
+        return TheTVDBProvider.isApiDiscontinuedError(err);
+    }
+
+    /**
+     * Log the reason for the show's failure to the given logger.
+     *
+     * This method does not check to see IF the show has failed.  It assumes
+     * the caller has some reason to assume there was a failure, and tries
+     * to provide as much information as it can.
+     *
+     * @param logger the logger object to send the failure message to
+     */
+    public void logShowFailure(Logger logger) {
+        logger.log(Level.WARNING, "failed to get show for " + getName(), err);
     }
 
     public FailedShow(String name, TVRenamerIOException err) {

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -359,7 +359,7 @@ public class FileEpisode {
         } else {
             actualEpisode = actualShow.getEpisode(seasonNum, episodeNum);
             if (actualEpisode == null) {
-                logger.log(Level.SEVERE, "Season #" + seasonNum + ", Episode #"
+                logger.log(Level.FINE, "Season #" + seasonNum + ", Episode #"
                            + episodeNum + " not found for show '"
                            + filenameShow + "'");
                 seriesStatus = SeriesStatus.NO_MATCH;
@@ -532,6 +532,24 @@ public class FileEpisode {
         }
     }
 
+    private String getNoMatchPlaceholder() {
+        return EPISODE_NOT_FOUND + " <" + actualShow.getName() + " / " + actualShow.getId()
+            + ">: " + " season " + seasonNum + ", episode " + episodeNum + " not found";
+    }
+
+    private String getNoListingsPlaceholder() {
+        return EPISODE_NOT_FOUND + " <" + actualShow.getName() + " / " + actualShow.getId()
+            + ">: " + DOWNLOADING_FAILED;
+    }
+
+    private String getNoShowPlaceholder() {
+        ShowName showName = ShowName.lookupShowName(filenameShow);
+        String queryString = showName.getQueryString();
+        return BROKEN_PLACEHOLDER_FILENAME + " \""
+            + StringUtils.decodeSpecialCharacters(queryString)
+            + "\"";
+    }
+
     private String getShowNamePlaceholder() {
         return "<" + actualShow.getName() + ">";
     }
@@ -560,16 +578,16 @@ public class FileEpisode {
                 }
             }
             case NO_MATCH: {
-                return BROKEN_PLACEHOLDER_FILENAME;
+                return getNoMatchPlaceholder();
             }
             case NO_LISTINGS: {
-                return DOWNLOADING_FAILED;
+                return getNoListingsPlaceholder();
             }
             case GOT_SHOW: {
                 return getShowNamePlaceholder();
             }
             case UNFOUND: {
-                return BROKEN_PLACEHOLDER_FILENAME;
+                return getNoShowPlaceholder();
             }
             default: {
                 if (seriesStatus != SeriesStatus.NOT_STARTED) {

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -43,12 +43,35 @@ public class FileEpisode {
         UNPARSED
     }
 
+    /**
+     * A status for how much we know about the Series and its listings.
+     *
+     * These are essentially in order, from most complete to least complete.
+     *
+     * <ul>
+     * <li>GOT_LISTINGS means we have matched this FileEpisode to an actual Episode,
+     *     based on the season and episode information we extracted from the filename</li>
+     * <li>NO_MATCH means we resolved the Show and downloaded the listings, but did
+     *     not find a match for the season and episode information</li>
+     * <li>NO_LISTINGS means something went wrong trying to download the Show's listings,
+     *     and we don't have any episode information</li>
+     * <li>GOT_SHOW is exactly the same state of information as NO_LISTINGS; the difference
+     *     is, GOT_SHOW means we are in the process of trying to download listings, whereas
+     *     NO_LISTINGS means we tried and have given up</li>
+     * <li>UNFOUND means we were unable to map the supposed show name that we found in the
+     *     filename, to an actual show from the provider</li>
+     * <li>NOT_STARTED means we have not started to query for information about the show.
+     *     In this case, to know more about what's going on, we need to look at the parse
+     *     status.  Refer to its comments for elaboration.</li>
+     * </ul>
+     */
     private enum SeriesStatus {
-        NOT_STARTED,
+        GOT_LISTINGS,
+        NO_MATCH,
+        NO_LISTINGS,
         GOT_SHOW,
         UNFOUND,
-        GOT_LISTINGS,
-        NO_LISTINGS
+        NOT_STARTED
     }
 
     private enum FileStatus {
@@ -313,7 +336,7 @@ public class FileEpisode {
         actualShow = show;
         if (actualShow == null) {
             logger.warning("setEpisodeShow should never be called with null");
-            seriesStatus = SeriesStatus.UNFOUND;
+            seriesStatus = SeriesStatus.NOT_STARTED;
         } else if (actualShow instanceof FailedShow) {
             seriesStatus = SeriesStatus.UNFOUND;
         } else {
@@ -324,11 +347,14 @@ public class FileEpisode {
     public boolean listingsComplete() {
         if (actualShow == null) {
             logger.warning("error: should not get listings, do not have show!");
-            seriesStatus = SeriesStatus.UNFOUND;
+            seriesStatus = SeriesStatus.NOT_STARTED;
             return false;
         } else if (actualShow instanceof FailedShow) {
             logger.warning("error: should not get listings, have a failed show!");
             seriesStatus = SeriesStatus.UNFOUND;
+            return false;
+        } else if (!actualShow.hasEpisodes()) {
+            seriesStatus = SeriesStatus.NO_LISTINGS;
             return false;
         } else {
             actualEpisode = actualShow.getEpisode(seasonNum, episodeNum);
@@ -336,7 +362,7 @@ public class FileEpisode {
                 logger.log(Level.SEVERE, "Season #" + seasonNum + ", Episode #"
                            + episodeNum + " not found for show '"
                            + filenameShow + "'");
-                seriesStatus = SeriesStatus.NO_LISTINGS;
+                seriesStatus = SeriesStatus.NO_MATCH;
                 return false;
             } else {
                 // Success!!!
@@ -516,15 +542,6 @@ public class FileEpisode {
      */
     public String getReplacementText() {
         switch (seriesStatus) {
-            case NOT_STARTED: {
-                return ADDED_PLACEHOLDER_FILENAME;
-            }
-            case GOT_SHOW: {
-                return getShowNamePlaceholder();
-            }
-            case UNFOUND: {
-                return BROKEN_PLACEHOLDER_FILENAME;
-            }
             case GOT_LISTINGS: {
                 if (userPrefs.isRenameEnabled()) {
                     String newFilename = getRenamedBasename() + filenameSuffix;
@@ -542,13 +559,34 @@ public class FileEpisode {
                     return fileNameString;
                 }
             }
+            case NO_MATCH: {
+                return BROKEN_PLACEHOLDER_FILENAME;
+            }
             case NO_LISTINGS: {
                 return DOWNLOADING_FAILED;
             }
-            default: {
-                logger.warning("internal error, seriesStatus check apparently not exhaustive: "
-                               + seriesStatus);
+            case GOT_SHOW: {
+                return getShowNamePlaceholder();
+            }
+            case UNFOUND: {
                 return BROKEN_PLACEHOLDER_FILENAME;
+            }
+            default: {
+                if (seriesStatus != SeriesStatus.NOT_STARTED) {
+                    logger.warning("internal error, seriesStatus check apparently not exhaustive: "
+                                   + seriesStatus);
+                }
+                switch (parseStatus) {
+                    case UNPARSED: {
+                        return EMPTY_STRING;
+                    }
+                    case BAD_PARSE: {
+                        return BAD_PARSE_MESSAGE;
+                    }
+                    default: {
+                        return ADDED_PLACEHOLDER_FILENAME;
+                    }
+                }
             }
         }
     }

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -304,20 +304,20 @@ public class FileEpisode {
             seriesStatus = SeriesStatus.UNFOUND;
         } else if (actualShow instanceof FailedShow) {
             seriesStatus = SeriesStatus.UNFOUND;
-            logger.log(Level.FINE, "failed to get show for " + fileNameString,
-                       ((FailedShow) show).getError());
         } else {
             seriesStatus = SeriesStatus.GOT_SHOW;
         }
     }
 
-    public void listingsComplete() {
+    public boolean listingsComplete() {
         if (actualShow == null) {
             logger.warning("error: should not get listings, do not have show!");
             seriesStatus = SeriesStatus.UNFOUND;
+            return false;
         } else if (actualShow instanceof FailedShow) {
             logger.warning("error: should not get listings, have a failed show!");
             seriesStatus = SeriesStatus.UNFOUND;
+            return false;
         } else {
             actualEpisode = actualShow.getEpisode(seasonNum, episodeNum);
             if (actualEpisode == null) {
@@ -325,9 +325,11 @@ public class FileEpisode {
                            + episodeNum + " not found for show '"
                            + filenameShow + "'");
                 seriesStatus = SeriesStatus.NO_LISTINGS;
+                return false;
             } else {
                 // Success!!!
                 seriesStatus = SeriesStatus.GOT_LISTINGS;
+                return true;
             }
         }
     }

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -25,10 +25,22 @@ import java.util.regex.Matcher;
 public class FileEpisode {
     private static final Logger logger = Logger.getLogger(FileEpisode.class.getName());
 
+    /**
+     * A status for how much we know about the filename.
+     *
+     * <ul>
+     * <li>PARSED means that we believe we have extracted all the required information from
+     *     the filename</li>
+     * <li>BAD_PARSE means we're not going to try to query for this FileEpisode, because
+     *     we could not find the show name.</li>
+     * <li>UNPARSED means we haven't yet finished examining the filename.</li>
+     * </ul>
+     *
+     */
     private enum ParseStatus {
-        UNPARSED,
         PARSED,
-        BAD_PARSE
+        BAD_PARSE,
+        UNPARSED
     }
 
     private enum SeriesStatus {

--- a/src/main/org/tvrenamer/model/LocalShow.java
+++ b/src/main/org/tvrenamer/model/LocalShow.java
@@ -16,6 +16,6 @@ public class LocalShow extends Show {
     }
 
     public LocalShow(String name) {
-        super(fakeId(), name, null);
+        super(fakeId(), name);
     }
 }

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -539,6 +539,35 @@ public class Show {
     }
 
     /**
+     * Find out if the results of querying for this show indicate that the API
+     * is no longer supported.
+     *
+     * @return true if the API is deprecated; false otherwise.
+     */
+    public boolean isApiDeprecated() {
+        // This method may return true for a subclass of Show (FailedShow).
+        // But for direct instances of the parent class (this class), we
+        // always return false.
+        return false;
+    }
+
+    /**
+     * Log the reason for the show's failure to the given logger.
+     *
+     * This method does not check to see IF the show has failed.  It assumes
+     * the caller has some reason to assume there was a failure, and tries
+     * to provide as much information as it can.
+     *
+     * @param logger the logger object to send the failure message to
+     */
+    public void logShowFailure(Logger logger) {
+        // This method does not make sense for this direct class.
+        // It has a more interesting implementation in its subclass.
+        logger.info("unexpected failure getting show for " + name
+                    + "; got " + this);
+    }
+
+    /**
      * Find out whether or not there are seasons associated with this show.
      * Generally this indicates that the show's listings have been downloaded,
      * the episodes have been organized into seasons, and the show is ready to go.

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -3,7 +3,6 @@ package org.tvrenamer.model;
 import org.tvrenamer.controller.ListingsLookup;
 import org.tvrenamer.controller.ShowListingsListener;
 import org.tvrenamer.controller.util.StringUtils;
-import org.tvrenamer.model.util.Constants;
 
 import java.util.LinkedList;
 import java.util.List;
@@ -74,7 +73,6 @@ public class Show {
     private final Integer idNum;
     private final String name;
     private final String dirName;
-    private final String imdb;
 
     private final Map<String, Episode> episodes;
     private final Map<Integer, Map<Integer, Episode>> seasons;
@@ -87,7 +85,7 @@ public class Show {
 
     /**
      * Create a Show object for a show that the provider knows about.  Initially
-     * we just get the show's name and ID, and an IMDB ID if known, but soon the
+     * we just get the show's name and ID, but soon the
      * Show will be augmented with all of its episodes.
      *
      * This class should not be used (directly) for any kind of "stand in".
@@ -97,13 +95,10 @@ public class Show {
      * @param name
      *     The proper name of this show, from the provider.  May contain a distinguisher,
      *     such as a year.
-     * @param imdb
-     *     The IMDB ID of this show, if known.  May be null.
      */
-    Show(String idString, String name, String imdb) {
+    Show(String idString, String name) {
         this.idString = idString;
         this.name = name;
-        this.imdb = imdb;
         dirName = StringUtils.sanitiseTitle(name);
 
         Integer parsedId = null;
@@ -133,16 +128,14 @@ public class Show {
      * @param name
      *     The proper name of this show, from the provider.  May contain a distinguisher,
      *     such as a year.
-     * @param imdb
-     *     The IMDB ID of this show, if known.  May be null.
      * @return a Show with the given ID
      */
-    public static Show getShowInstance(String id, String name, String imdb) {
+    public static Show getShowInstance(String id, String name) {
         Show matchedShow;
         synchronized (KNOWN_SHOWS) {
             matchedShow = KNOWN_SHOWS.get(id);
             if (matchedShow == null) {
-                matchedShow = new Show(id, name, imdb);
+                matchedShow = new Show(id, name);
             }
         }
         return matchedShow;
@@ -243,17 +236,6 @@ public class Show {
      */
     public String getDirName() {
         return dirName;
-    }
-
-    /**
-     * Get a string version of the IMDB URL, if the IMDB id is known.
-     *
-     * @return URL
-     *            the IMDB URL for this show, if known
-     */
-    @SuppressWarnings("unused")
-    public String getImdbUrl() {
-        return (imdb == null) ? "" : Constants.IMDB_BASE_URL + imdb;
     }
 
     /**
@@ -608,7 +590,7 @@ public class Show {
      */
     @Override
     public String toString() {
-        return "Show [" + name + ", id=" + idString + ", imdb=" + imdb + ", "
+        return "Show [" + name + ", id=" + idString + ", "
             + episodes.size() + " episodes]";
     }
 }

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -510,7 +510,7 @@ public class Show {
     public Episode getEpisode(int seasonNum, int episodeNum) {
         Map<Integer, Episode> season = seasons.get(seasonNum);
         if (season == null) {
-            logger.warning("no season " + seasonNum + " found for show " + name);
+            logger.fine("no season " + seasonNum + " found for show " + name);
             return null;
         }
         Episode episode = season.get(episodeNum);
@@ -568,7 +568,6 @@ public class Show {
      *
      * @return a count of how many episodes we have for this Show
      */
-    @SuppressWarnings("unused")
     public boolean hasEpisodes() {
         return (episodes.size() > 0);
     }

--- a/src/main/org/tvrenamer/model/ShowName.java
+++ b/src/main/org/tvrenamer/model/ShowName.java
@@ -178,12 +178,10 @@ public class ShowName {
     private static class ShowOption {
         final String id;
         final String actualName;
-        final String imdb;
 
-        ShowOption(final String id, final String actualName, final String imdb) {
+        ShowOption(final String id, final String actualName) {
             this.id = id;
             this.actualName = actualName;
-            this.imdb = imdb;
         }
     }
 
@@ -285,14 +283,9 @@ public class ShowName {
      *    the show's id in the TVDB database
      * @param seriesName
      *    the "official" show name
-     * @param imdbId
-     *    the show's id in IMDB
      */
-    public void addShowOption(final String tvdbId,
-                              final String seriesName,
-                              final String imdbId)
-    {
-        ShowOption option = new ShowOption(tvdbId, seriesName, imdbId);
+    public void addShowOption(final String tvdbId, final String seriesName) {
+        ShowOption option = new ShowOption(tvdbId, seriesName);
         showOptions.add(option);
     }
 
@@ -353,7 +346,7 @@ public class ShowName {
             selected = showOptions.get(0);
         }
 
-        Show selectedShow = Show.getShowInstance(selected.id, selected.actualName, selected.imdb);
+        Show selectedShow = Show.getShowInstance(selected.id, selected.actualName);
         queryString.setShow(selectedShow);
         return selectedShow;
     }

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -148,8 +148,6 @@ public class Constants {
     private static final String PREFERENCES_FILENAME = "prefs.xml";
     private static final String OVERRIDES_FILENAME = "overrides.xml";
 
-    public static final String IMDB_BASE_URL = "http://www.imdb.com/title/";
-
     @SuppressWarnings("WeakerAccess")
     public static final Path USER_HOME_DIR = Paths.get(Environment.USER_HOME);
     public static final Path WORKING_DIRECTORY = Paths.get(Environment.USER_DIR);

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -131,9 +131,10 @@ public class Constants {
     public static final String ERROR_PARSING_NUMBERS = ERROR_PARSING_XML
         + ": a field expected to be a number was not";
     public static final String ADDED_PLACEHOLDER_FILENAME = "Downloading ...";
+    public static final String EPISODE_NOT_FOUND = "Could not get episode for show";
     public static final String BROKEN_PLACEHOLDER_FILENAME = "Unable to find show information";
     public static final String DOWNLOADING_FAILED = "Downloading show listings failed";
-    public static final String BAD_PARSE_MESSAGE = "Could not find show name in filename";
+    public static final String BAD_PARSE_MESSAGE = "Did not extract show name from filename";
     public static final String DOWNLOADING_FAILED_MESSAGE = DOWNLOADING_FAILED
         + ".  Check internet connection";
     public static final String FILE_EPISODE_NEEDS_PATH = "cannot create FileEpisode with no path";

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -133,6 +133,7 @@ public class Constants {
     public static final String ADDED_PLACEHOLDER_FILENAME = "Downloading ...";
     public static final String BROKEN_PLACEHOLDER_FILENAME = "Unable to find show information";
     public static final String DOWNLOADING_FAILED = "Downloading show listings failed";
+    public static final String BAD_PARSE_MESSAGE = "Could not find show name in filename";
     public static final String DOWNLOADING_FAILED_MESSAGE = DOWNLOADING_FAILED
         + ".  Check internet connection";
     public static final String FILE_EPISODE_NEEDS_PATH = "cannot create FileEpisode with no path";

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -1,5 +1,6 @@
 package org.tvrenamer.model.util;
 
+import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
@@ -29,6 +30,8 @@ import java.nio.file.Paths;
  *
  */
 public class Constants {
+
+    public static final Charset TVR_CHARSET = Charset.forName("UTF-8");
 
     public static final String APPLICATION_NAME = "TVRenamer";
 
@@ -113,6 +116,16 @@ public class Constants {
         + "to take some action.";
     public static final String UNKNOWN_EXCEPTION = "An error occurred, please check "
         + "the console output to see any errors:";
+
+    public static final String TO_DOWNLOAD = "Please visit " + TVRENAMER_PROJECT_URL
+        + " to download the new version.";
+    public static final String GET_UPDATE_MESSAGE = "This version of TVRenamer is no longer "
+        + "functional.  There is a new version available, which should work. "
+        + TO_DOWNLOAD;
+    public static final String NEED_UPDATE = "This version of TVRenamer is no longer "
+        + "functional.  There is a not currently a new version available, but please "
+        + "check " + TVRENAMER_PROJECT_URL + " to see when one comes available.";
+    public static final String API_DISCONTINUED = "API apparently discontinued";
 
     public static final String ERROR_PARSING_XML = "Error parsing XML";
     public static final String ERROR_PARSING_NUMBERS = ERROR_PARSING_XML

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -92,6 +92,10 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
     private TaskItem taskItem = null;
 
     private UserPreferences prefs;
+    private Thread updateCheckThread = null;
+    private boolean updateIsAvailable = false;
+    private boolean apiDeprecated = false;
+
     private final EpisodeDb episodeMap = new EpisodeDb();
 
     private void init() {
@@ -150,13 +154,11 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
         });
 
         // Show the label if updates are available (in a new thread)
-        Thread updateCheckThread = new Thread(() -> {
-            if (prefs.checkForUpdates()) {
-                final boolean updatesAvailable = UpdateChecker.isUpdateAvailable();
+        updateCheckThread = new Thread(() -> {
+            updateIsAvailable = UpdateChecker.isUpdateAvailable();
 
-                if (updatesAvailable) {
-                    display.asyncExec(() -> updatesAvailableLink.setVisible(true));
-                }
+            if (updateIsAvailable && prefs.checkForUpdates()) {
+                display.asyncExec(() -> updatesAvailableLink.setVisible(true));
             }
         });
         updateCheckThread.start();
@@ -576,6 +578,25 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
         });
     }
 
+    private synchronized void noteShowFailure(final String fileName, final Show show) {
+        if (!apiDeprecated) {
+            if (show.isApiDeprecated()) {
+                apiDeprecated = true;
+                try {
+                    updateCheckThread.join();
+                } catch (InterruptedException e) {
+                    updateIsAvailable = false;
+                }
+                showMessageBox(SWTMessageBoxType.ERROR, ERROR_LABEL,
+                               updateIsAvailable ? GET_UPDATE_MESSAGE : NEED_UPDATE);
+            } else {
+                show.logShowFailure(logger);
+            }
+            // else, do nothing.  Once we have detected the deprecated API, and
+            // posted a dialog about it, it's no longer worth noting.
+        }
+    }
+
     @Override
     public void addEpisodes(Queue<FileEpisode> episodes) {
         // Update the list of ignored keywords
@@ -598,6 +619,7 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
                     public void downloadFailed(Show show) {
                         episode.setEpisodeShow(show);
                         tableItemFailed(item);
+                        noteShowFailure(fileName, show);
                     }
                 });
         }

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -537,7 +537,7 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
         episode.listingsFailed(err);
         display.asyncExec(() -> {
             if (tableContainsTableItem(item)) {
-                item.setText(NEW_FILENAME_COLUMN, DOWNLOADING_FAILED);
+                item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
                 item.setImage(STATUS_COLUMN, FileMoveIcon.FAIL.icon);
                 item.setChecked(false);
             }
@@ -568,10 +568,10 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
         });
     }
 
-    private void tableItemFailed(TableItem item) {
+    private void tableItemFailed(TableItem item, FileEpisode episode) {
         display.asyncExec(() -> {
             if (tableContainsTableItem(item)) {
-                item.setText(NEW_FILENAME_COLUMN, BROKEN_PLACEHOLDER_FILENAME);
+                item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
                 item.setImage(STATUS_COLUMN, FileMoveIcon.FAIL.icon);
                 item.setChecked(false);
             }
@@ -618,7 +618,7 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
                     @Override
                     public void downloadFailed(Show show) {
                         episode.setEpisodeShow(show);
-                        tableItemFailed(item);
+                        tableItemFailed(item, episode);
                         noteShowFailure(fileName, show);
                     }
                 });


### PR DESCRIPTION
Propagate changes from v0.8 to detect when the old API becomes deprecated.

In this branch, we're going to switch to the v2 API, and so this should become moot.  But have it as a background, in any case.

Some other changes.  Please see individual commits for details.