### PR TITLE
Update Mac debug steps to use JavaAppLauncher

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ If the application doesn't start with a java error, [ensure that your JAVA_HOME 
   * On OSX:
     1. Open the Terminal application (at /Applications/Utilities/Terminal.app)
     1. Navigate to where the TVRenamer application is.
-    1. Execute it via `./TVRenamer-<version>.app/Contents/MacOS/run-mac.sh`
+    1. Execute it via `./TVRenamer-<version>.app/Contents/MacOS/JavaAppLauncher`
   * On Linux:
     1. Open the Terminal application (from the Gnome Applications menu)
     1. Navigate to where the TVRenamer application is.


### PR DESCRIPTION
Update Mac debug steps to use JavaAppLauncher instead of run-mac.sh in README.md