### PR TITLE
Fix typo and move constant strings

### DIFF
--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -31,19 +31,35 @@ import java.nio.file.Paths;
 public class Constants {
 
     public static final String APPLICATION_NAME = "TVRenamer";
+    public static final String ABOUT_LABEL = "About " + APPLICATION_NAME;
+    public static final String TVRENAMER_DESCRIPTION = APPLICATION_NAME
+        + " is a Java GUI utility to rename TV episodes from TV listings";
 
     public static final String VERSION_NUMBER = Environment.readVersionNumber();
+    public static final String VERSION_LABEL = "Version: " + VERSION_NUMBER;
 
     public static final String TVRENAMER_PROJECT_URL = "http://tvrenamer.org";
     public static final String TVRENAMER_DOWNLOAD_URL = TVRENAMER_PROJECT_URL + "/downloads";
-    public static final String TVRENAMER_PROJECT_ISSUES_URL = TVRENAMER_PROJECT_URL + "/issues";
+    public static final String TVRENAMER_ISSUES_URL = TVRENAMER_PROJECT_URL + "/issues";
     public static final String TVRENAMER_VERSION_URL = TVRENAMER_PROJECT_URL + "/version";
     public static final String TVRENAMER_REPOSITORY_URL = TVRENAMER_PROJECT_URL + "/source";
     public static final String TVRENAMER_SUPPORT_EMAIL = "support@tvrenamer.org";
+    public static final String TVRENAMER_LICENSE_URL = "http://www.gnu.org/licenses/gpl-2.0.html";
+
+    public static final String EMAIL_LINK = "mailto:" + TVRENAMER_SUPPORT_EMAIL;
+
+    public static final String LICENSE_TEXT_1 = "Licensed under the ";
+    public static final String LICENSE_TEXT_2 = "GNU General Public License v2";
+    public static final String PROJECT_PAGE = "Project Page";
+    public static final String ISSUE_TRACKER = "Issue Tracker";
+    public static final String SEND_SUPPORT_EMAIL = "Send support email";
+    public static final String SOURCE_CODE_LINK = "Source Code";
 
     public static final String XML_SUFFIX = ".xml";
     public static final String ICON_PARENT_DIRECTORY = "res";
     public static final String TVRENAMER_ICON_PATH = "/icons/tvrenamer.png";
+    public static final String TVRENAMER_ICON_DIRECT_PATH =
+        ICON_PARENT_DIRECTORY + TVRENAMER_ICON_PATH;
     public static final String LOGGING_PROPERTIES = "/logging.properties";
     public static final String DEVELOPER_DEFAULT_OVERRIDES_FILENAME = "etc/default-overrides.xml";
 
@@ -52,6 +68,7 @@ public class Constants {
     public static final String SAVE_LABEL = "Save";
     public static final String ERROR_LABEL = "Error";
     public static final String EXIT_LABEL = "Exit";
+    public static final String OK_LABEL = "OK";
     public static final String PREFERENCES_LABEL = "Preferences";
     public static final String FILE_MOVE_THREAD_LABEL = "MoveRunnerThread";
     public static final String RENAME_LABEL = "Rename Selected";
@@ -114,6 +131,14 @@ public class Constants {
     public static final String UNKNOWN_EXCEPTION = "An error occurred, please check "
         + "the console output to see any errors:";
 
+    public static final String UPDATE_TEXT = "Check for Updates...";
+    public static final String NEW_VERSION_TITLE = "New Version Available!";
+    public static final String NEW_VERSION_AVAILABLE = "There is a new version available!\n\n"
+        + "You are currently running " + VERSION_NUMBER + ", but there is an update available\n\n"
+        + "Please visit " + TVRENAMER_PROJECT_URL + " to download the new version.";
+    public static final String NO_NEW_VERSION_TITLE = "No New Version Available";
+    public static final String NO_NEW_VERSION_AVAILABLE = "There is no new version available\n\n"
+        + "Please check the website (" + TVRENAMER_PROJECT_URL + ") for any news or check back later.";
     public static final String TO_DOWNLOAD = "Please visit " + TVRENAMER_PROJECT_URL
         + " to download the new version.";
     public static final String GET_UPDATE_MESSAGE = "This version of TVRenamer is no longer "

--- a/src/main/org/tvrenamer/view/AboutDialog.java
+++ b/src/main/org/tvrenamer/view/AboutDialog.java
@@ -30,8 +30,6 @@ import java.util.logging.Logger;
 final class AboutDialog extends Dialog {
     private static final Logger logger = Logger.getLogger(AboutDialog.class.getName());
 
-    private static final String TVRENAMER_LICENSE_URL = "http://www.gnu.org/licenses/gpl-2.0.html";
-
     private Shell aboutShell;
 
     /**
@@ -47,7 +45,7 @@ final class AboutDialog extends Dialog {
     public void open() {
         // Create the dialog window
         aboutShell = new Shell(getParent(), getStyle());
-        aboutShell.setText("About TVRenamer");
+        aboutShell.setText(ABOUT_LABEL);
 
         // Add the contents of the dialog window
         createContents();
@@ -89,11 +87,11 @@ final class AboutDialog extends Dialog {
         iconGridData.grabExcessHorizontalSpace = false;
         iconLabel.setLayoutData(iconGridData);
 
-        InputStream icon = getClass().getResourceAsStream("/icons/tvrenamer.png");
+        InputStream icon = getClass().getResourceAsStream(TVRENAMER_ICON_PATH);
         if (icon != null) {
             iconLabel.setImage(new Image(Display.getCurrent(), icon));
         } else {
-            iconLabel.setImage(new Image(Display.getCurrent(), "res/icons/tvrenamer.png"));
+            iconLabel.setImage(new Image(Display.getCurrent(), TVRENAMER_ICON_DIRECT_PATH));
         }
 
         Label applicationLabel = new Label(aboutShell, SWT.NONE);
@@ -108,12 +106,12 @@ final class AboutDialog extends Dialog {
                                       getDefaultSystemFont().getHeight() + 2,
                                       SWT.BOLD));
 
-        versionLabel.setText("Version: " + VERSION_NUMBER);
+        versionLabel.setText(VERSION_LABEL);
         versionLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, true));
 
         Label descriptionLabel = new Label(aboutShell, SWT.NONE);
         descriptionLabel.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER, true, true));
-        descriptionLabel.setText("TVRenamer is a Java GUI utility to rename TV episodes from TV listings");
+        descriptionLabel.setText(TVRENAMER_DESCRIPTION);
     }
 
     /**
@@ -139,11 +137,11 @@ final class AboutDialog extends Dialog {
      *
      */
     private void createLinks() {
-        createUrlLink("Licensed under the ", TVRENAMER_LICENSE_URL, "GNU General Public License v2");
-        createUrlLink("", TVRENAMER_PROJECT_URL, "Project Page");
-        createUrlLink("", TVRENAMER_PROJECT_ISSUES_URL, "Issue Tracker");
-        createUrlLink("", "mailto:" + TVRENAMER_SUPPORT_EMAIL, "Send support email");
-        createUrlLink("", TVRENAMER_REPOSITORY_URL, "Source Code");
+        createUrlLink(LICENSE_TEXT_1, TVRENAMER_LICENSE_URL, LICENSE_TEXT_2);
+        createUrlLink("", TVRENAMER_PROJECT_URL, PROJECT_PAGE);
+        createUrlLink("", TVRENAMER_ISSUES_URL, ISSUE_TRACKER);
+        createUrlLink("", EMAIL_LINK, SEND_SUPPORT_EMAIL);
+        createUrlLink("", TVRENAMER_REPOSITORY_URL, SOURCE_CODE_LINK);
     }
 
     /**
@@ -152,7 +150,7 @@ final class AboutDialog extends Dialog {
      */
     private void createButtons() {
         Button updateCheckButton = new Button(aboutShell, SWT.PUSH);
-        updateCheckButton.setText("Check for Updates...");
+        updateCheckButton.setText(UPDATE_TEXT);
         GridData gridDataUpdateCheck = new GridData();
         gridDataUpdateCheck.widthHint = 160;
         gridDataUpdateCheck.horizontalAlignment = GridData.END;
@@ -164,29 +162,18 @@ final class AboutDialog extends Dialog {
                 boolean updateAvailable = UpdateChecker.isUpdateAvailable();
 
                 if (updateAvailable) {
-                    String message = "There is a new version available!\n\n"
-                        + "You are currently running "
-                        + VERSION_NUMBER
-                        + ", but there is an update available\n\n"
-                        + "Please visit "
-                        + TVRENAMER_PROJECT_URL
-                        + " to download the new version.";
-
-                    logger.fine(message);
-                    UIUtils.showMessageBox(SWTMessageBoxType.OK, "New Version Available!", message);
+                    logger.fine(NEW_VERSION_AVAILABLE);
+                    UIUtils.showMessageBox(SWTMessageBoxType.OK, NEW_VERSION_TITLE,
+                                           NEW_VERSION_AVAILABLE);
                 } else {
-                    String message = "There is a no new version available\n\n"
-                        + "Please check the website ("
-                        + TVRENAMER_PROJECT_URL
-                        + ") for any news or check back later.";
-                    UIUtils.showMessageBox(SWTMessageBoxType.WARNING, "No New Version Available",
-                                           message);
+                    UIUtils.showMessageBox(SWTMessageBoxType.WARNING, NO_NEW_VERSION_TITLE,
+                                           NO_NEW_VERSION_AVAILABLE);
                 }
             }
         });
 
         Button okButton = new Button(aboutShell, SWT.PUSH);
-        okButton.setText("OK");
+        okButton.setText(OK_LABEL);
         GridData gridDataOK = new GridData();
         gridDataOK.widthHint = 160;
         gridDataOK.horizontalAlignment = GridData.END;


### PR DESCRIPTION
Noticed a typo in the dialog box: it said "There is a no new version available"; that " a " was ungrammatical.

I thought I'd find the text in Constants.java, but it wasn't there.  There were still a lot of constant strings in AboutDialog.java.  So, move them all into Constants.java, while fixing the one typo.