### PR TITLE
Improve behavior with UNC paths, more

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -74,7 +74,6 @@
   <target name="compile.test" depends="compile">
     <javac srcdir="${src.test}" destdir="${build}" classpathref="classpath.test" debug="true" debuglevel="lines,vars,source" includeantruntime="false" />
     <copy file="${version.file}" todir="${build}" />
-    <copy file="${logging.file}" todir="${build}" />
   </target>
 
   <macrodef name="build.jar" description="Compiles the source then creates an executable jar for the given platform">

--- a/src/main/org/tvrenamer/controller/FileMover.java
+++ b/src/main/org/tvrenamer/controller/FileMover.java
@@ -239,23 +239,9 @@ public class FileMover implements Callable<Boolean> {
             }
             filename = destBasename + VERSION_SEPARATOR_STRING + destIndex + destSuffix;
         }
-        if (Files.notExists(destDir)) {
-            try {
-                Files.createDirectories(destDir);
-            } catch (IOException ioe) {
-                logger.log(Level.SEVERE, "Unable to create directory " + destDir, ioe);
-                return false;
-            }
-        }
-        if (!Files.exists(destDir)) {
-            logger.warning("could not create destination directory " + destDir
-                           + "; not attempting to move " + srcPath);
-            return false;
-        }
-        if (!Files.isDirectory(destDir)) {
-            logger.warning("cannot use specified destination " + destDir
-                           + "because it is not a directory; not attempting to move "
-                           + srcPath);
+
+        if (!FileUtilities.ensureWritableDirectory(destDir)) {
+            logger.warning("not attempting to move " + srcPath);
             return false;
         }
 

--- a/src/main/org/tvrenamer/controller/util/FileUtilities.java
+++ b/src/main/org/tvrenamer/controller/util/FileUtilities.java
@@ -93,6 +93,43 @@ public class FileUtilities {
         return Files.exists(dir);
     }
 
+    /**
+     * Takes a Path which is a directory that the user wants to write into.  Makes sure
+     * that the directory exists (or creates it if it doesn't) and is writable.  If the
+     * directory cannot be created, or is not a directory, or is not writable, this method
+     * fails.
+     *
+     * @param destDir
+     *    the Path that the caller will want to write into
+     * @return true if, upon completion of this method, the desired Path exists, is a
+     *         directory, and is writable.  False otherwise.
+     */
+    public static boolean ensureWritableDirectory(final Path destDir) {
+        if (Files.notExists(destDir)) {
+            try {
+                Files.createDirectories(destDir);
+            } catch (IOException ioe) {
+                logger.log(Level.SEVERE, "Unable to create directory " + destDir, ioe);
+                return false;
+            }
+        }
+        if (!Files.exists(destDir)) {
+            logger.warning("could not create destination directory " + destDir);
+            return false;
+        }
+        if (!Files.isDirectory(destDir)) {
+            logger.warning("cannot use specified destination " + destDir
+                           + " because it is not a directory");
+            return false;
+        }
+        if (!Files.isWritable(destDir)) {
+            logger.warning("cannot write file to " + destDir);
+            return false;
+        }
+
+        return true;
+    }
+
     @SuppressWarnings("WeakerAccess")
     public static boolean isDirEmpty(final Path dir) {
         try (DirectoryStream<Path> dirStream = Files.newDirectoryStream(dir)) {

--- a/src/main/org/tvrenamer/controller/util/FileUtilities.java
+++ b/src/main/org/tvrenamer/controller/util/FileUtilities.java
@@ -17,6 +17,14 @@ import java.util.logging.Logger;
 public class FileUtilities {
     private static final Logger logger = Logger.getLogger(FileUtilities.class.getName());
 
+    public static void loggingOff() {
+        logger.setLevel(Level.SEVERE);
+    }
+
+    public static void loggingOn() {
+        logger.setLevel(Level.INFO);
+    }
+
     @SuppressWarnings("UnusedReturnValue")
     public static boolean deleteFile(Path source) {
         if (Files.notExists(source)) {

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -67,10 +67,13 @@ public class TheTVDBProviderTest {
      *
      * @param epdata contains all the relevant information about the episode to look up, and
      *               what we expect to get back about it
+     * @param doCheck whether or not to check that the episode title matches the expected
      * @return the title of the given episode of the show returned by the provider, or null
      *         if we didn't get an episode title
      */
-    public String testSeriesNameAndEpisodeTitle(final EpisodeTestData epdata) throws Exception {
+    public String testSeriesNameAndEpisode(final EpisodeTestData epdata, boolean doCheck)
+        throws Exception
+    {
         final String actualName = epdata.properShowName;
         final ShowName showName = ShowName.lookupShowName(actualName);
 
@@ -96,8 +99,26 @@ public class TheTVDBProviderTest {
             return null;
         }
         final String foundTitle = ep.getTitle();
-        assertEpisodeTitle(epdata, foundTitle);
+        if (doCheck) {
+            assertEpisodeTitle(epdata, foundTitle);
+        }
         return foundTitle;
+    }
+
+    /**
+     * Contacts the provider to look up a show and an episode, and returns true if we found the show
+     * and the episode title matches the given expected value.
+     *
+     * Note that this method does not simply waits for the providers responses.  We don't use
+     * callbacks here, so we're not testing that aspect of the real program.
+     *
+     * @param epdata contains all the relevant information about the episode to look up, and
+     *               what we expect to get back about it
+     * @return the title of the given episode of the show returned by the provider, or null
+     *         if we didn't get an episode title
+     */
+    public String testSeriesNameAndEpisodeTitle(final EpisodeTestData epdata) throws Exception {
+        return testSeriesNameAndEpisode(epdata, true);
     }
 
     /**

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -43,6 +43,22 @@ import java.util.concurrent.TimeoutException;
 public class TheTVDBProviderTest {
 
     /**
+     * Fails if the given title does not match the expected title within the EpisodeTestData.
+     *
+     * @param epdata contains all the relevant information about the episode to look up, and
+     *               what we expect to get back about it
+     * @param foundTitle the value that was found for the episode title
+     */
+    public void assertEpisodeTitle(final EpisodeTestData epdata, final String foundTitle) {
+        final String expectedTitle = epdata.episodeTitle;
+        if (!expectedTitle.equals(foundTitle)) {
+            fail("expected title of season " + epdata.seasonNum + ", episode " + epdata.episodeNum
+                 + " of " + epdata.properShowName + " to be \"" + expectedTitle
+                 + "\", but got \"" + foundTitle + "\"");
+        }
+    }
+
+    /**
      * Contacts the provider to look up a show and an episode, and returns true if we found the show
      * and the episode title matches the given expected value.
      *
@@ -80,12 +96,7 @@ public class TheTVDBProviderTest {
             return null;
         }
         final String foundTitle = ep.getTitle();
-        final String dvdTitle = epdata.episodeTitle;
-        if (!dvdTitle.equals(foundTitle)) {
-            fail("expected title of season " + epdata.seasonNum + ", episode " + epdata.episodeNum
-                 + " of " + actualName + " to be \"" + dvdTitle
-                 + "\", but got \"" + foundTitle + "\"");
-        }
+        assertEpisodeTitle(epdata, foundTitle);
         return foundTitle;
     }
 
@@ -962,7 +973,7 @@ public class TheTVDBProviderTest {
                     });
 
                     String got = future.get(30, TimeUnit.SECONDS);
-                    assertEquals(testInput.episodeTitle, got);
+                    assertEpisodeTitle(testInput, got);
                 } catch (TimeoutException e) {
                     String failMsg = "timeout trying to query for " + queryString
                         + ", season " + seasonNum + ", episode " + episodeNum;

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -137,6 +137,7 @@ public class TheTVDBProviderTest {
     public static void setupValues01() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("game of thrones")
+                   .properShowName("Game of Thrones")
                    .seasonNum(5)
                    .episodeNum(1)
                    .episodeTitle("The Wars to Come")
@@ -147,6 +148,7 @@ public class TheTVDBProviderTest {
     public static void setupValues02() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("24")
+                   .properShowName("24")
                    .seasonNum(8)
                    .episodeNum(1)
                    .episodeTitle("Day 8: 4:00 P.M. - 5:00 P.M.")
@@ -157,6 +159,7 @@ public class TheTVDBProviderTest {
     public static void setupValues03() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("24")
+                   .properShowName("24")
                    .seasonNum(7)
                    .episodeNum(18)
                    .episodeTitle("Day 7: 1:00 A.M. - 2:00 A.M.")
@@ -167,6 +170,7 @@ public class TheTVDBProviderTest {
     public static void setupValues04() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("human target 2010")
+                   .properShowName("Human Target (2010)")
                    .seasonNum(1)
                    .episodeNum(2)
                    .episodeTitle("Rewind")
@@ -177,6 +181,7 @@ public class TheTVDBProviderTest {
     public static void setupValues05() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("dexter")
+                   .properShowName("Dexter")
                    .seasonNum(4)
                    .episodeNum(7)
                    .episodeTitle("Slack Tide")
@@ -187,6 +192,7 @@ public class TheTVDBProviderTest {
     public static void setupValues06() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("jag")
+                   .properShowName("JAG")
                    .seasonNum(10)
                    .episodeNum(1)
                    .episodeTitle("Hail and Farewell, Part II (2)")
@@ -197,6 +203,7 @@ public class TheTVDBProviderTest {
     public static void setupValues07() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("lost")
+                   .properShowName("Lost")
                    .seasonNum(6)
                    .episodeNum(5)
                    .episodeTitle("Lighthouse")
@@ -207,6 +214,7 @@ public class TheTVDBProviderTest {
     public static void setupValues08() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("warehouse 13")
+                   .properShowName("Warehouse 13")
                    .seasonNum(1)
                    .episodeNum(1)
                    .episodeTitle("Pilot")
@@ -217,6 +225,7 @@ public class TheTVDBProviderTest {
     public static void setupValues09() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("one tree hill")
+                   .properShowName("One Tree Hill")
                    .seasonNum(7)
                    .episodeNum(14)
                    .episodeTitle("Family Affair")
@@ -227,6 +236,7 @@ public class TheTVDBProviderTest {
     public static void setupValues10() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("gossip girl")
+                   .properShowName("Gossip Girl")
                    .seasonNum(3)
                    .episodeNum(15)
                    .episodeTitle("The Sixteen Year Old Virgin")
@@ -237,6 +247,7 @@ public class TheTVDBProviderTest {
     public static void setupValues11() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("smallville")
+                   .properShowName("Smallville")
                    .seasonNum(9)
                    .episodeNum(14)
                    .episodeTitle("Conspiracy")
@@ -247,6 +258,7 @@ public class TheTVDBProviderTest {
     public static void setupValues12() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("smallville")
+                   .properShowName("Smallville")
                    .seasonNum(9)
                    .episodeNum(15)
                    .episodeTitle("Escape")
@@ -257,6 +269,7 @@ public class TheTVDBProviderTest {
     public static void setupValues13() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("the big bang theory")
+                   .properShowName("The Big Bang Theory")
                    .seasonNum(3)
                    .episodeNum(18)
                    .episodeTitle("The Pants Alternative")
@@ -267,6 +280,7 @@ public class TheTVDBProviderTest {
     public static void setupValues14() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("castle 2009")
+                   .properShowName("Castle (2009)")
                    .seasonNum(1)
                    .episodeNum(9)
                    .episodeTitle("Little Girl Lost")
@@ -277,6 +291,7 @@ public class TheTVDBProviderTest {
     public static void setupValues15() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("dexter")
+                   .properShowName("Dexter")
                    .seasonNum(5)
                    .episodeNum(5)
                    .episodeTitle("First Blood")
@@ -287,6 +302,7 @@ public class TheTVDBProviderTest {
     public static void setupValues16() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("lost")
+                   .properShowName("Lost")
                    .seasonNum(2)
                    .episodeNum(7)
                    .episodeTitle("The Other 48 Days")
@@ -297,6 +313,7 @@ public class TheTVDBProviderTest {
     public static void setupValues17() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("american dad")
+                   .properShowName("American Dad!")
                    .seasonNum(9)
                    .episodeNum(17)
                    .episodeTitle("The Full Cognitive Redaction of Avery Bullock by the Coward Stan Smith")
@@ -307,6 +324,7 @@ public class TheTVDBProviderTest {
     public static void setupValues18() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("californication")
+                   .properShowName("Californication")
                    .seasonNum(7)
                    .episodeNum(4)
                    .episodeTitle("Dicks")
@@ -317,6 +335,7 @@ public class TheTVDBProviderTest {
     public static void setupValues19() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("continuum")
+                   .properShowName("Continuum")
                    .seasonNum(3)
                    .episodeNum(7)
                    .episodeTitle("Waning Minutes")
@@ -327,6 +346,7 @@ public class TheTVDBProviderTest {
     public static void setupValues20() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("elementary")
+                   .properShowName("Elementary")
                    .seasonNum(2)
                    .episodeNum(23)
                    .episodeTitle("Art in the Blood")
@@ -337,6 +357,7 @@ public class TheTVDBProviderTest {
     public static void setupValues21() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("family guy")
+                   .properShowName("Family Guy")
                    .seasonNum(12)
                    .episodeNum(19)
                    .episodeTitle("Meg Stinks!")
@@ -347,6 +368,7 @@ public class TheTVDBProviderTest {
     public static void setupValues22() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("fargo")
+                   .properShowName("Fargo")
                    .seasonNum(1)
                    .episodeNum(1)
                    .episodeTitle("The Crocodile's Dilemma")
@@ -357,6 +379,7 @@ public class TheTVDBProviderTest {
     public static void setupValues23() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("girls")
+                   .properShowName("Girls")
                    .seasonNum(3)
                    .episodeNum(11)
                    .episodeTitle("I Saw You")
@@ -367,6 +390,7 @@ public class TheTVDBProviderTest {
     public static void setupValues24() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("grimm")
+                   .properShowName("Grimm")
                    .seasonNum(3)
                    .episodeNum(19)
                    .episodeTitle("Nobody Knows the Trubel I've Seen")
@@ -377,6 +401,7 @@ public class TheTVDBProviderTest {
     public static void setupValues25() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("house of cards 2013")
+                   .properShowName("House of Cards (US)")
                    .seasonNum(1)
                    .episodeNum(6)
                    .episodeTitle("Chapter 6")
@@ -387,6 +412,7 @@ public class TheTVDBProviderTest {
     public static void setupValues26() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("modern family")
+                   .properShowName("Modern Family")
                    .seasonNum(5)
                    .episodeNum(12)
                    .episodeTitle("Under Pressure")
@@ -397,6 +423,7 @@ public class TheTVDBProviderTest {
     public static void setupValues27() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("new girl")
+                   .properShowName("New Girl")
                    .seasonNum(3)
                    .episodeNum(23)
                    .episodeTitle("Cruise")
@@ -407,6 +434,7 @@ public class TheTVDBProviderTest {
     public static void setupValues28() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("nurse jackie")
+                   .properShowName("Nurse Jackie")
                    .seasonNum(6)
                    .episodeNum(4)
                    .episodeTitle("Jungle Love")
@@ -419,6 +447,7 @@ public class TheTVDBProviderTest {
         // the same season and episode, but different IDs
         values.add(new EpisodeTestData.Builder()
                    .queryString("offspring")
+                   .properShowName("Offspring")
                    .seasonNum(5)
                    .episodeNum(1)
                    .episodeTitle("Back in the Game")
@@ -429,6 +458,7 @@ public class TheTVDBProviderTest {
     public static void setupValues30() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("reign 2013")
+                   .properShowName("Reign (2013)")
                    .seasonNum(1)
                    .episodeNum(20)
                    .episodeTitle("Higher Ground")
@@ -441,6 +471,7 @@ public class TheTVDBProviderTest {
         // and regular numbering.
         values.add(new EpisodeTestData.Builder()
                    .queryString("robot chicken")
+                   .properShowName("Robot Chicken")
                    .seasonNum(7)
                    .episodeNum(4)
                    .episodeTitle("Rebel Appliance")
@@ -451,6 +482,7 @@ public class TheTVDBProviderTest {
     public static void setupValues32() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("supernatural")
+                   .properShowName("Supernatural")
                    .seasonNum(9)
                    .episodeNum(21)
                    .episodeTitle("King of the Damned")
@@ -461,6 +493,7 @@ public class TheTVDBProviderTest {
     public static void setupValues33() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("the americans 2013")
+                   .properShowName("The Americans (2013)")
                    .seasonNum(2)
                    .episodeNum(10)
                    .episodeTitle("Yousaf")
@@ -471,6 +504,7 @@ public class TheTVDBProviderTest {
     public static void setupValues34() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("the big bang theory")
+                   .properShowName("The Big Bang Theory")
                    .seasonNum(7)
                    .episodeNum(23)
                    .episodeTitle("The Gorilla Dissolution")
@@ -483,6 +517,7 @@ public class TheTVDBProviderTest {
         // currently (2017/06/02) comes through unparseable.
         values.add(new EpisodeTestData.Builder()
                    .queryString("the good wife")
+                   .properShowName("The Good Wife")
                    .seasonNum(5)
                    .episodeNum(20)
                    .episodeTitle("The Deep Web")
@@ -495,6 +530,7 @@ public class TheTVDBProviderTest {
         // We issue a warning, but it's not really a problem.
         values.add(new EpisodeTestData.Builder()
                    .queryString("the walking dead")
+                   .properShowName("The Walking Dead")
                    .seasonNum(4)
                    .episodeNum(16)
                    .episodeTitle("A")
@@ -505,6 +541,7 @@ public class TheTVDBProviderTest {
     public static void setupValues37() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("veep")
+                   .properShowName("Veep")
                    .seasonNum(3)
                    .episodeNum(5)
                    .episodeTitle("Fishing")
@@ -515,6 +552,7 @@ public class TheTVDBProviderTest {
     public static void setupValues38() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("witches of east end")
+                   .properShowName("Witches of East End")
                    .seasonNum(1)
                    .episodeNum(1)
                    .episodeTitle("Pilot")
@@ -525,6 +563,7 @@ public class TheTVDBProviderTest {
     public static void setupValues39() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("warehouse 13")
+                   .properShowName("Warehouse 13")
                    .seasonNum(5)
                    .episodeNum(4)
                    .episodeTitle("Savage Seduction")
@@ -535,6 +574,7 @@ public class TheTVDBProviderTest {
     public static void setupValues40() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("the 100")
+                   .properShowName("The 100")
                    .seasonNum(2)
                    .episodeNum(8)
                    .episodeTitle("Spacewalker")
@@ -545,6 +585,7 @@ public class TheTVDBProviderTest {
     public static void setupValues41() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(1)
                    .episodeTitle("Serenity")
@@ -555,6 +596,7 @@ public class TheTVDBProviderTest {
     public static void setupValues42() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(2)
                    .episodeTitle("The Train Job")
@@ -565,6 +607,7 @@ public class TheTVDBProviderTest {
     public static void setupValues43() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(3)
                    .episodeTitle("Bushwhacked")
@@ -575,6 +618,7 @@ public class TheTVDBProviderTest {
     public static void setupValues44() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(4)
                    .episodeTitle("Shindig")
@@ -585,6 +629,7 @@ public class TheTVDBProviderTest {
     public static void setupValues45() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(5)
                    .episodeTitle("Safe")
@@ -595,6 +640,7 @@ public class TheTVDBProviderTest {
     public static void setupValues46() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(6)
                    .episodeTitle("Our Mrs. Reynolds")
@@ -605,6 +651,7 @@ public class TheTVDBProviderTest {
     public static void setupValues47() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(7)
                    .episodeTitle("Jaynestown")
@@ -615,6 +662,7 @@ public class TheTVDBProviderTest {
     public static void setupValues48() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(8)
                    .episodeTitle("Out of Gas")
@@ -625,6 +673,7 @@ public class TheTVDBProviderTest {
     public static void setupValues49() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(9)
                    .episodeTitle("Ariel")
@@ -635,6 +684,7 @@ public class TheTVDBProviderTest {
     public static void setupValues50() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(10)
                    .episodeTitle("War Stories")
@@ -645,6 +695,7 @@ public class TheTVDBProviderTest {
     public static void setupValues51() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(11)
                    .episodeTitle("Trash")
@@ -655,6 +706,7 @@ public class TheTVDBProviderTest {
     public static void setupValues52() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(12)
                    .episodeTitle("The Message")
@@ -665,6 +717,7 @@ public class TheTVDBProviderTest {
     public static void setupValues53() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(13)
                    .episodeTitle("Heart of Gold")
@@ -675,6 +728,7 @@ public class TheTVDBProviderTest {
     public static void setupValues54() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("firefly")
+                   .properShowName("Firefly")
                    .seasonNum(1)
                    .episodeNum(14)
                    .episodeTitle("Objects in Space")
@@ -687,6 +741,7 @@ public class TheTVDBProviderTest {
         // resolves to the correct show.
         values.add(new EpisodeTestData.Builder()
                    .queryString("strike back")
+                   .properShowName("Strike Back")
                    .seasonNum(1)
                    .episodeNum(1)
                    .episodeTitle("Chris Ryan's Strike Back, Episode 1")
@@ -697,6 +752,7 @@ public class TheTVDBProviderTest {
     public static void setupValues56() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("law and order svu")
+                   .properShowName("Law & Order: Special Victims Unit")
                    .seasonNum(17)
                    .episodeNum(5)
                    .episodeTitle("Community Policing")
@@ -707,6 +763,7 @@ public class TheTVDBProviderTest {
     public static void setupValues57() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("ncis")
+                   .properShowName("NCIS")
                    .seasonNum(13)
                    .episodeNum(4)
                    .episodeTitle("Double Trouble")
@@ -717,6 +774,7 @@ public class TheTVDBProviderTest {
     public static void setupValues58() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("marvels agents of shield")
+                   .properShowName("Marvel's Agents of S.H.I.E.L.D.")
                    .seasonNum(3)
                    .episodeNum(3)
                    .episodeTitle("A Wanted (Inhu)man")
@@ -727,6 +785,7 @@ public class TheTVDBProviderTest {
     public static void setupValues59() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("marvels agents of shield")
+                   .properShowName("Marvel's Agents of S.H.I.E.L.D.")
                    .seasonNum(3)
                    .episodeNum(10)
                    .episodeTitle("Maveth")
@@ -737,6 +796,7 @@ public class TheTVDBProviderTest {
     public static void setupValues60() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("nip tuck")
+                   .properShowName("Nip/Tuck")
                    .seasonNum(6)
                    .episodeNum(1)
                    .episodeTitle("Don Hoberman")
@@ -747,6 +807,7 @@ public class TheTVDBProviderTest {
     public static void setupValues61() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("the big bang theory")
+                   .properShowName("The Big Bang Theory")
                    .seasonNum(10)
                    .episodeNum(4)
                    .episodeTitle("The Cohabitation Experimentation")
@@ -759,6 +820,7 @@ public class TheTVDBProviderTest {
         // (season "0", episode "2")
         values.add(new EpisodeTestData.Builder()
                    .queryString("lucifer")
+                   .properShowName("Lucifer")
                    .seasonNum(2)
                    .episodeNum(3)
                    .episodeTitle("Sin-Eater")
@@ -769,6 +831,7 @@ public class TheTVDBProviderTest {
     public static void setupValues63() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("marvels agents of shield")
+                   .properShowName("Marvel's Agents of S.H.I.E.L.D.")
                    .seasonNum(4)
                    .episodeNum(3)
                    .episodeTitle("Uprising")
@@ -779,6 +842,7 @@ public class TheTVDBProviderTest {
     public static void setupValues64() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("supernatural")
+                   .properShowName("Supernatural")
                    .seasonNum(11)
                    .episodeNum(22)
                    .episodeTitle("We Happy Few")
@@ -789,6 +853,7 @@ public class TheTVDBProviderTest {
     public static void setupValues65() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("channel zero")
+                   .properShowName("Channel Zero")
                    .seasonNum(1)
                    .episodeNum(1)
                    .episodeTitle("You Have to Go Inside")
@@ -799,6 +864,7 @@ public class TheTVDBProviderTest {
     public static void setupValues66() {
         values.add(new EpisodeTestData.Builder()
                    .queryString("ncis")
+                   .properShowName("NCIS")
                    .seasonNum(14)
                    .episodeNum(4)
                    .episodeTitle("Love Boat")
@@ -838,7 +904,7 @@ public class TheTVDBProviderTest {
                 return null;
             }
             assertFalse(gotShow instanceof LocalShow);
-            // assertEquals(testInput.actualShowName, gotShow.getName());
+            assertEquals(testInput.properShowName, gotShow.getName());
             return gotShow;
         } catch (TimeoutException e) {
             String failMsg = "timeout trying to query for " + queryString;

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -157,6 +157,44 @@ public class TheTVDBProviderTest {
                                       .build());
     }
 
+    /**
+     * Third download test.  This one is chosen to ensure we are consistent
+     * with the numbering scheme.  If we use DVD ordering, it should be for
+     * DVD season _and_ DVD episode, and if we use regular, it should be
+     * both regular.
+     *
+     * This assumes the following information:
+     *    DVD season 4, DVD episode 10: "The Why of Fry"
+     *    air season 4, air episode 10: "A Leela of Her Own"
+     *    air season 4, DVD episode 10: "Where the Buggalo Roam"
+     *
+     * Of course, it makes no sense to look at "air season" and "DVD episode".
+     * But that's what we accidentally did in early versions of the program.
+     * So this test is intended to verify that the bug is fixed, and check
+     * that we don't regress.
+     */
+    @Test
+    public void testSeasonMatchesEpisode() throws Exception {
+        final String dvdTitle = "The Why of Fry";
+        final String airedTitle = "A Leela of Her Own";
+        final String jumbledTitle = "Where the Buggalo Roam";
+        EpisodeTestData s04e10 = new EpisodeTestData.Builder()
+            .properShowName("Futurama")
+            .showId("73871")
+            .seasonNum(4)
+            .episodeNum(10)
+            .episodeTitle(dvdTitle)
+            .build();
+        final String foundTitle = testSeriesNameAndEpisode(s04e10, false);
+        if (airedTitle.equals(foundTitle)) {
+            fail("expected to get DVD ordering for Futurama, but got over-the-air ordering");
+        }
+        if (jumbledTitle.equals(foundTitle)) {
+            fail("expected to get purely DVD ordering for Futurama, but got over-the-air season");
+        }
+        assertEpisodeTitle(s04e10, foundTitle);
+    }
+
     private static final List<EpisodeTestData> values = new LinkedList<>();
 
     /*

--- a/src/test/org/tvrenamer/controller/util/FileUtilsTest.java
+++ b/src/test/org/tvrenamer/controller/util/FileUtilsTest.java
@@ -1,0 +1,128 @@
+package org.tvrenamer.controller.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermission;
+import java.util.HashSet;
+import java.util.Set;
+
+public class FileUtilsTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    @BeforeClass
+    public static void setLogging() {
+        FileUtilities.loggingOff();
+    }
+
+    @Test
+    public void testEnsureWritableDirectory() {
+        final String dirname = "folder";
+
+        final Path sandbox = tempFolder.getRoot().toPath();
+
+        final Path dirpath = sandbox.resolve(dirname);
+        assertFalse("cannot test ensureWritableDirectory because target already exists",
+                    Files.exists(dirpath));
+
+        assertTrue("ensureWritableDirectory returned false",
+                   FileUtilities.ensureWritableDirectory(dirpath));
+        assertTrue("dir from ensureWritableDirectory not found",
+                   Files.exists(dirpath));
+        assertTrue("dir from ensureWritableDirectory not a directory",
+                   Files.isDirectory(dirpath));
+
+        assertTrue("rmdirs returned false", FileUtilities.rmdir(dirpath));
+        assertFalse("dir from rmdirs not removed", Files.exists(dirpath));
+    }
+
+    @Test
+    public void testEnsureWritableDirectoryAlreadyExists() {
+        final Path dirpath = tempFolder.getRoot().toPath();
+
+        assertTrue("cannot test ensureWritableDirectory because sandbox does not exist",
+                   Files.exists(dirpath));
+
+        assertTrue("ensureWritableDirectory returned false",
+                   FileUtilities.ensureWritableDirectory(dirpath));
+        assertTrue("dir from ensureWritableDirectory not found",
+                   Files.exists(dirpath));
+        assertTrue("dir from ensureWritableDirectory not a directory",
+                   Files.isDirectory(dirpath));
+    }
+
+    @Test
+    public void testEnsureWritableDirectoryFileInTheWay() {
+        final String dirname = "file";
+        Path dirpath;
+
+        try {
+            dirpath = tempFolder.newFile(dirname).toPath();
+        } catch (IOException ioe) {
+            fail("cannot test ensureWritableDirectory because newFile failed");
+            return;
+        }
+
+        assertTrue("cannot test ensureWritableDirectory because file does not exist",
+                   Files.exists(dirpath));
+
+        assertFalse("ensureWritableDirectory returned true when file was in the way",
+                    FileUtilities.ensureWritableDirectory(dirpath));
+        assertTrue("file from ensureWritableDirectory not found",
+                   Files.exists(dirpath));
+        assertFalse("file from ensureWritableDirectory is a directory",
+                    Files.isDirectory(dirpath));
+    }
+
+    @Test
+    public void testEnsureWritableDirectoryCantWrite() {
+        final String dirname = "folder";
+        File myFolder;
+
+        try {
+            myFolder = tempFolder.newFolder(dirname);
+        } catch (Exception e) {
+            fail("cannot test ensureWritableDirectory because newFolder failed");
+            return;
+        }
+
+        Path dirpath = myFolder.toPath();
+        assertTrue("cannot test ensureWritableDirectory because folder does not exist",
+                   Files.exists(dirpath));
+
+        try {
+            Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
+            perms.add(PosixFilePermission.OWNER_READ);
+            perms.add(PosixFilePermission.OWNER_EXECUTE);
+            Files.setPosixFilePermissions(dirpath, perms);
+        } catch (UnsupportedOperationException ue) {
+            // If this platform can't support POSIX file permissions, then we just
+            // punt.  We can't properly test it, so there is no failure.
+            return;
+        } catch (IOException ioe) {
+            fail("cannot test ensureWritableDirectory because newFile failed");
+            return;
+        }
+
+        assertFalse("failed to make temp dir not writable", Files.isWritable(dirpath));
+
+        assertFalse("ensureWritableDirectory returned true when folder was not writable",
+                    FileUtilities.ensureWritableDirectory(dirpath));
+        assertTrue("file from ensureWritableDirectory not found",
+                   Files.exists(dirpath));
+        assertTrue("file from ensureWritableDirectory is a directory",
+                   Files.isDirectory(dirpath));
+    }
+}

--- a/src/test/org/tvrenamer/model/EpisodeTestData.java
+++ b/src/test/org/tvrenamer/model/EpisodeTestData.java
@@ -1,10 +1,6 @@
 package org.tvrenamer.model;
 
-import java.util.logging.Logger;
-
 public class EpisodeTestData {
-    private static final Logger logger = Logger.getLogger(EpisodeTestData.class.getName());
-
     private static final String EMPTY_STRING = "";
     private static final String DEFAULT_SEPARATOR = ".";
     private static final String DEFAULT_SHOW_ID = "1";


### PR DESCRIPTION
A few changes.

Improve testing in TheTVDBProviderTest by checking the proper show names.

Some cleanup around logging.

We had already fixed bug #168, but add a test that verifies the fix more explicitly, to be sure we don't regress.

More some folder manipulation code into FileUtilities, and add testing for it.

Use toRealPath() on the source and destination files of a move, so that it becomes clear when files are on the same file system, even if one or both of them is using UNC paths.