### PR TITLE
Update check box when episode not found

### DIFF
--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -309,25 +309,31 @@ public class FileEpisode {
         }
     }
 
-    public void listingsComplete() {
+    public boolean listingsComplete() {
         if (actualShow == null) {
             logger.warning("error: should not get listings, do not have show!");
             seriesStatus = SeriesStatus.UNFOUND;
-        } else if (actualShow instanceof FailedShow) {
+            return false;
+        }
+
+        if (actualShow instanceof FailedShow) {
             logger.warning("error: should not get listings, have a failed show!");
             seriesStatus = SeriesStatus.UNFOUND;
-        } else {
-            actualEpisode = actualShow.getEpisode(seasonNum, episodeNum);
-            if (actualEpisode == null) {
-                logger.log(Level.SEVERE, "Season #" + seasonNum + ", Episode #"
-                           + episodeNum + " not found for show '"
-                           + filenameShow + "'");
-                seriesStatus = SeriesStatus.NO_LISTINGS;
-            } else {
-                // Success!!!
-                seriesStatus = SeriesStatus.GOT_LISTINGS;
-            }
+            return false;
         }
+
+        actualEpisode = actualShow.getEpisode(seasonNum, episodeNum);
+        if (actualEpisode == null) {
+            logger.log(Level.SEVERE, "Season #" + seasonNum + ", Episode #"
+                       + episodeNum + " not found for show '"
+                       + filenameShow + "'");
+            seriesStatus = SeriesStatus.NO_LISTINGS;
+            return false;
+        }
+
+        // Success!!!
+        seriesStatus = SeriesStatus.GOT_LISTINGS;
+        return true;
     }
 
     public void listingsFailed(Exception err) {

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -524,11 +524,17 @@ public final class UIStarter implements Observer,  AddEpisodeListener {
     }
 
     private void listingsDownloaded(TableItem item, FileEpisode episode) {
-        episode.listingsComplete();
+        boolean epFound = episode.listingsComplete();
         display.asyncExec(() -> {
             if (tableContainsTableItem(item)) {
                 item.setText(NEW_FILENAME_COLUMN, episode.getReplacementText());
-                item.setImage(STATUS_COLUMN, FileMoveIcon.ADDED.icon);
+                if (epFound) {
+                    item.setImage(STATUS_COLUMN, FileMoveIcon.ADDED.icon);
+                    item.setChecked(true);
+                } else {
+                    item.setImage(STATUS_COLUMN, FileMoveIcon.FAIL.icon);
+                    item.setChecked(false);
+                }
             }
         });
     }


### PR DESCRIPTION
When we create the table items, they are checked by default.  Then if there's a problem with the episode, we uncheck the box.  It probably should be reversed, but leaving it as is, for now...

In the case where we find the show, and successfully download the listings, we were assuming that nothing went wrong.  If the particular episode was not found, we did actually show an error message; that's just from calling the "replacement name".  But we didn't uncheck the box.

We were already calling FileEpisode.listingsComplete() to *set* the SeriesStatus of the FileEpisode.  It just was never getting communicated back to the UI.

So change FileEpisode.listingsComplete() to a boolean, that returns true only if the specific episode was found, and false otherwise.

Then change UIStarter to check the return value, and uncheck the box if listingsComplete() returns false.

Conflicts:
	src/main/org/tvrenamer/model/FileEpisode.java
	src/main/org/tvrenamer/view/UIStarter.java