### PR TITLE
Revert changes around API v1 deprecation

### DIFF
--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -16,11 +16,8 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
-import java.time.LocalDate;
-import java.time.Month;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -34,12 +31,6 @@ public class TheTVDBProvider {
 
     // The unique API key for our application
     private static final String API_KEY = "4A9560FF0B2670B2";
-
-    // The proposed day on which the v1 API will cease to be supported.
-    private static final LocalDate SUNSET = LocalDate.of(2017, Month.OCTOBER, 1);
-
-    // Whether or not we should try making v1 API calls
-    private static boolean apiIsDeprecated = false;
 
     // The base information for the provider
     private static final String DEFAULT_SITE_URL = "http://thetvdb.com/";
@@ -72,31 +63,9 @@ public class TheTVDBProvider {
     private static final String XPATH_DVD_EPISODE_NUM = "DVD_episodenumber";
     // private static final String XPATH_EPISODE_NUM_ABS = "absolute_number";
 
-    public static boolean isApiDiscontinuedError(Throwable e) {
-        if (0 > LocalDate.now().compareTo(SUNSET)) {
-            return false;
-        }
-        while (e != null) {
-            if (e instanceof FileNotFoundException) {
-                apiIsDeprecated = true;
-                return true;
-            }
-            e = e.getCause();
-        }
-        return false;
-    }
-
-    public static boolean isApiDeprecated() {
-        return apiIsDeprecated;
-    }
-
     private static String getShowSearchXml(final ShowName showName)
         throws TVRenamerIOException
     {
-        if (apiIsDeprecated) {
-            throw new TVRenamerIOException(API_DISCONTINUED, null);
-        }
-
         String searchURL = BASE_SEARCH_URL + showName.getQueryString();
 
         logger.fine("About to download search results from " + searchURL);
@@ -109,10 +78,6 @@ public class TheTVDBProvider {
     private static String getShowListingXml(final Show show)
         throws TVRenamerIOException
     {
-        if (apiIsDeprecated) {
-            throw new TVRenamerIOException(API_DISCONTINUED, null);
-        }
-
         Integer showId = show.getId();
         if (showId == null) {
             throw new TVRenamerIOException("cannot download listings for show "
@@ -179,11 +144,7 @@ public class TheTVDBProvider {
         } catch (TVRenamerIOException tve) {
             String msg  = "error parsing XML from " + searchXml + " for series "
                 + showName.getFoundName();
-            if (isApiDiscontinuedError(tve)) {
-                throw new TVRenamerIOException(API_DISCONTINUED, tve);
-            } else {
-                logger.log(Level.WARNING, msg, tve);
-            }
+            logger.log(Level.WARNING, msg, tve);
             throw new TVRenamerIOException(msg, tve);
         }
     }

--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -36,7 +36,7 @@ public class TheTVDBProvider {
     private static final String API_KEY = "4A9560FF0B2670B2";
 
     // The proposed day on which the v1 API will cease to be supported.
-    private static final LocalDate SUNSET = LocalDate.of(2017, Month.DECEMBER, 1);
+    private static final LocalDate SUNSET = LocalDate.of(2017, Month.OCTOBER, 1);
 
     // Whether or not we should try making v1 API calls
     private static boolean apiIsDeprecated = false;
@@ -73,9 +73,6 @@ public class TheTVDBProvider {
     // private static final String XPATH_EPISODE_NUM_ABS = "absolute_number";
 
     public static boolean isApiDiscontinuedError(Throwable e) {
-        if (apiIsDeprecated) {
-            return true;
-        }
         if (0 > LocalDate.now().compareTo(SUNSET)) {
             return false;
         }
@@ -87,6 +84,10 @@ public class TheTVDBProvider {
             e = e.getCause();
         }
         return false;
+    }
+
+    public static boolean isApiDeprecated() {
+        return apiIsDeprecated;
     }
 
     private static String getShowSearchXml(final ShowName showName)

--- a/src/main/org/tvrenamer/model/FailedShow.java
+++ b/src/main/org/tvrenamer/model/FailedShow.java
@@ -1,35 +1,12 @@
 package org.tvrenamer.model;
 
-import org.tvrenamer.controller.TheTVDBProvider;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
 class FailedShow extends LocalShow {
 
+    @SuppressWarnings("FieldCanBeLocal")
     private final TVRenamerIOException err;
 
-    /**
-     * Find out if the results of querying for this show indicate that the API
-     * is no longer supported.
-     *
-     * @return true if the API is deprecated; false otherwise.
-     */
-    public boolean isApiDeprecated() {
-        return TheTVDBProvider.isApiDiscontinuedError(err);
-    }
-
-    /**
-     * Log the reason for the show's failure to the given logger.
-     *
-     * This method does not check to see IF the show has failed.  It assumes
-     * the caller has some reason to assume there was a failure, and tries
-     * to provide as much information as it can.
-     *
-     * @param logger the logger object to send the failure message to
-     */
-    public void logShowFailure(Logger logger) {
-        logger.log(Level.WARNING, "failed to get show for " + getName(), err);
+    public TVRenamerIOException getError() {
+        return err;
     }
 
     public FailedShow(String name, TVRenamerIOException err) {

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -473,36 +473,6 @@ public class Show {
     }
 
     /**
-     * Find out if the results of querying for this show indicate that the API
-     * is no longer supported.
-     *
-     * @return true if the API is deprecated; false otherwise.
-     */
-    public boolean isApiDeprecated() {
-        // This method may return true for a subclass of Show (FailedShow).
-        // But for direct instances of the parent class (this class), we
-        // always return false.
-        return false;
-    }
-
-    /**
-     * Log the reason for the show's failure to the given logger.
-     *
-     * This method does not check to see IF the show has failed.  It assumes
-     * the caller has some reason to assume there was a failure, and tries
-     * to provide as much information as it can.
-     *
-     * @param logger the logger object to send the failure message to
-     */
-    @SuppressWarnings("SameParameterValue")
-    public void logShowFailure(Logger logger) {
-        // This method does not make sense for this direct class.
-        // It has a more interesting implementation in its subclass.
-        logger.info("unexpected failure getting show for " + name
-                    + "; got " + this);
-    }
-
-    /**
      * Find out whether or not there are seasons associated with this show.
      * Generally this indicates that the show's listings have been downloaded,
      * the episodes have been organized into seasons, and the show is ready to go.

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -144,13 +144,6 @@ public class Constants {
     public static final String NO_NEW_VERSION_TITLE = "No New Version Available";
     public static final String NO_NEW_VERSION_AVAILABLE = "There is no new version available\n\n"
         + "Please check the website (" + TVRENAMER_PROJECT_URL + ") for any news or check back later.";
-    public static final String GET_UPDATE_MESSAGE = "This version of TVRenamer is no longer "
-        + "functional.  There is a new version available, which should work. "
-        + TO_DOWNLOAD;
-    public static final String NEED_UPDATE = "This version of TVRenamer is no longer "
-        + "functional.  There is a not currently a new version available, but please "
-        + "check " + TVRENAMER_PROJECT_URL + " to see when one comes available.";
-    public static final String API_DISCONTINUED = "API apparently discontinued";
 
     public static final String ERROR_PARSING_XML = "Error parsing XML";
     public static final String ERROR_PARSING_NUMBERS = ERROR_PARSING_XML


### PR DESCRIPTION
The v1 API was scheduled to be deprecated on October 1.  I kind of rushed some changes in to try to deal with it.  Then the deprecation was postponed.

It will still be deprecated.  We still need to deal with it.  But I'm backing out the changes, and will kind of start from scratch.
