### PR TITLE
Rework UpdateChecker

### DIFF
--- a/src/main/org/tvrenamer/controller/UpdateChecker.java
+++ b/src/main/org/tvrenamer/controller/UpdateChecker.java
@@ -3,6 +3,7 @@ package org.tvrenamer.controller;
 import static org.tvrenamer.model.util.Constants.*;
 
 import org.tvrenamer.model.TVRenamerIOException;
+import org.tvrenamer.model.UserPreferences;
 
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -10,29 +11,62 @@ import java.util.logging.Logger;
 public class UpdateChecker {
     private static final Logger logger = Logger.getLogger(UpdateChecker.class.getName());
 
+    private static Boolean newVersionAvailable = null;
+    private static String latestVersion;
+
     /**
      * Checks if a newer version is available.
      *
      * @return true if a new version is available, false if there is no new version or
      *          if an error has occurred
      */
-    public static boolean isUpdateAvailable() {
-        String latestVersion;
+    private static synchronized boolean checkIfUpdateAvailable() {
+        boolean available = false;
         try {
             latestVersion = new HttpConnectionHandler().downloadUrl(TVRENAMER_VERSION_URL);
+            available = latestVersion.compareToIgnoreCase(VERSION_NUMBER) > 0;
         } catch (TVRenamerIOException e) {
             // Do nothing when an exception is thrown, just don't update display
-            logger.log(Level.SEVERE, "Exception when downloading version file " + TVRENAMER_VERSION_URL, e);
-            return false;
+            logger.log(Level.SEVERE, "Exception when downloading version file " + TVRENAMER_VERSION_URL,
+                       e);
         }
 
-        boolean newVersionAvailable = latestVersion.compareToIgnoreCase(VERSION_NUMBER) > 0;
+        return available;
+    }
 
+    /**
+     * Checks if a newer version is available.
+     *
+     * @return true if a new version is available, false if there is no new version or
+     *          if an error has occurred
+     */
+    private static synchronized boolean isUpdateAvailable() {
+        if (newVersionAvailable == null) {
+            newVersionAvailable = checkIfUpdateAvailable();
+        }
         if (newVersionAvailable) {
-            logger.info("There is a new version available, running " + VERSION_NUMBER + ", new version is "
-                + latestVersion);
+            logger.info("There is a new version available, running " + VERSION_NUMBER
+                        + ", new version is " + latestVersion);
             return true;
         }
+        logger.finer("You have the latest version!");
         return false;
+    }
+
+    /**
+     * Notifies the listener whether or not a new version is available
+     *
+     * @param listener
+     *   the listener to update of whether or not an update is available
+     */
+    public static void notifyOfUpdate(final UpdateListener listener) {
+        Thread updateCheckThread = new Thread(() -> {
+            boolean doNotify = false;
+            if (UserPreferences.getInstance().checkForUpdates()) {
+                doNotify = isUpdateAvailable();
+            }
+            listener.notifyUpdateStatus(doNotify);
+        });
+        updateCheckThread.start();
     }
 }

--- a/src/main/org/tvrenamer/controller/UpdateListener.java
+++ b/src/main/org/tvrenamer/controller/UpdateListener.java
@@ -1,0 +1,5 @@
+package org.tvrenamer.controller;
+
+public interface UpdateListener {
+    void notifyUpdateStatus(boolean updateIsAvailable);
+}

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -141,6 +141,8 @@ public class Constants {
     public static final String NEW_VERSION_AVAILABLE = "There is a new version available!\n\n"
         + "You are currently running " + VERSION_NUMBER + ", but there is an update available\n\n"
         + TO_DOWNLOAD;
+    public static final String UPDATE_AVAILABLE = "There is an update available. <a href=\""
+        + TVRENAMER_DOWNLOAD_URL + "\">Click here to download</a>";
     public static final String NO_NEW_VERSION_TITLE = "No New Version Available";
     public static final String NO_NEW_VERSION_AVAILABLE = "There is no new version available\n\n"
         + "Please check the website (" + TVRENAMER_PROJECT_URL + ") for any news or check back later.";

--- a/src/main/org/tvrenamer/view/AboutDialog.java
+++ b/src/main/org/tvrenamer/view/AboutDialog.java
@@ -42,16 +42,16 @@ final class AboutDialog extends Dialog {
          */
         @Override
         public void widgetSelected(SelectionEvent arg0) {
-            boolean updateAvailable = UpdateChecker.isUpdateAvailable();
-
-            if (updateAvailable) {
-                logger.fine(NEW_VERSION_AVAILABLE);
-                UIUtils.showMessageBox(SWTMessageBoxType.OK, NEW_VERSION_TITLE,
-                                       NEW_VERSION_AVAILABLE);
-            } else {
-                UIUtils.showMessageBox(SWTMessageBoxType.WARNING, NO_NEW_VERSION_TITLE,
-                                       NO_NEW_VERSION_AVAILABLE);
-            }
+            UpdateChecker.notifyOfUpdate(updateIsAvailable -> {
+                if (updateIsAvailable) {
+                    logger.fine(NEW_VERSION_AVAILABLE);
+                    UIUtils.showMessageBox(SWTMessageBoxType.OK, NEW_VERSION_TITLE,
+                                           NEW_VERSION_AVAILABLE);
+                } else {
+                    UIUtils.showMessageBox(SWTMessageBoxType.WARNING, NO_NEW_VERSION_TITLE,
+                                           NO_NEW_VERSION_AVAILABLE);
+                }
+            });
         }
     }
 

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -84,7 +84,6 @@ public final class UIStarter implements Observer, AddEpisodeListener {
     private Button addFilesButton;
     private Button addFolderButton;
     private Button clearFilesButton;
-    private Link updatesAvailableLink;
     private Button renameSelectedButton;
     private Table resultsTable;
     private ProgressBar totalProgressBar;
@@ -123,6 +122,21 @@ public final class UIStarter implements Observer, AddEpisodeListener {
         shell.pack(true);
     }
 
+    private void setupUpdateStuff(final Composite parentComposite) {
+        Link updatesAvailableLink = new Link(parentComposite, SWT.VERTICAL);
+        // updatesAvailableLink.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, true));
+        updatesAvailableLink.setVisible(false);
+        updatesAvailableLink.setText(UPDATE_AVAILABLE);
+        updatesAvailableLink.addSelectionListener(new UrlLauncher(TVRENAMER_DOWNLOAD_URL));
+
+        // Show the label if updates are available (in a new thread)
+        UpdateChecker.notifyOfUpdate(updateIsAvailable -> {
+            if (updateIsAvailable) {
+                display.asyncExec(() -> updatesAvailableLink.setVisible(true));
+            }
+        });
+    }
+
     private void setupMainWindow() {
         final Composite topButtonsComposite = new Composite(shell, SWT.FILL);
         topButtonsComposite.setLayout(new RowLayout());
@@ -136,25 +150,7 @@ public final class UIStarter implements Observer, AddEpisodeListener {
         clearFilesButton = new Button(topButtonsComposite, SWT.PUSH);
         clearFilesButton.setText("Clear List");
 
-        updatesAvailableLink = new Link(topButtonsComposite, SWT.VERTICAL);
-        //updatesAvailableLink.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, true));
-        updatesAvailableLink.setVisible(false);
-        updatesAvailableLink.setText("There is an update available. <a href=\"" + TVRENAMER_DOWNLOAD_URL
-            + "\">Click here to download</a>");
-        updatesAvailableLink.addSelectionListener(new UrlLauncher(TVRENAMER_DOWNLOAD_URL));
-
-        // Show the label if updates are available (in a new thread)
-        Thread updateCheckThread = new Thread(() -> {
-            if (prefs.checkForUpdates()) {
-                final boolean updatesAvailable = UpdateChecker.isUpdateAvailable();
-
-                if (updatesAvailable) {
-                    display.asyncExec(() -> updatesAvailableLink.setVisible(true));
-                }
-            }
-        });
-        updateCheckThread.start();
-
+        setupUpdateStuff(topButtonsComposite);
         setupResultsTable();
         setupTableDragDrop();
 


### PR DESCRIPTION
When we want to download the latest version available, create the thread in UpdateChecker, rather than in UIStarter.

Add a new type of listener, org/tvrenamer/controller/UpdateListener.java, and use it to allow the UpdateChecker to initiate the action when we know whether or not a new version is available.

This helps keep a greater separation between view and controller.