### PR TITLE
Detect deprecated API

### DIFF
--- a/src/main/org/tvrenamer/controller/ShowInformationListener.java
+++ b/src/main/org/tvrenamer/controller/ShowInformationListener.java
@@ -3,7 +3,9 @@ package org.tvrenamer.controller;
 import org.tvrenamer.model.Show;
 
 public interface ShowInformationListener {
-    void downloaded(Show show);
+    void downloadSucceeded(Show show);
 
     void downloadFailed(Show show);
+
+    void apiHasBeenDeprecated();
 }

--- a/src/main/org/tvrenamer/controller/TheTVDBProvider.java
+++ b/src/main/org/tvrenamer/controller/TheTVDBProvider.java
@@ -4,6 +4,7 @@ import static org.tvrenamer.controller.util.XPathUtilities.nodeListValue;
 import static org.tvrenamer.controller.util.XPathUtilities.nodeTextValue;
 import static org.tvrenamer.model.util.Constants.*;
 
+import org.tvrenamer.model.DiscontinuedApiException;
 import org.tvrenamer.model.EpisodeInfo;
 import org.tvrenamer.model.Show;
 import org.tvrenamer.model.ShowName;
@@ -16,8 +17,11 @@ import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
+import java.time.LocalDate;
+import java.time.Month;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -31,6 +35,12 @@ public class TheTVDBProvider {
 
     // The unique API key for our application
     private static final String API_KEY = "4A9560FF0B2670B2";
+
+    // The proposed day on which the v1 API will cease to be supported.
+    private static final LocalDate SUNSET = LocalDate.of(2017, Month.DECEMBER, 1);
+
+    // Whether or not we should try making v1 API calls
+    private static boolean apiIsDeprecated = false;
 
     // The base information for the provider
     private static final String DEFAULT_SITE_URL = "http://thetvdb.com/";
@@ -64,8 +74,12 @@ public class TheTVDBProvider {
     // private static final String XPATH_EPISODE_NUM_ABS = "absolute_number";
 
     private static String getShowSearchXml(final ShowName showName)
-        throws TVRenamerIOException
+        throws TVRenamerIOException, DiscontinuedApiException
     {
+        if (apiIsDeprecated) {
+            throw new DiscontinuedApiException();
+        }
+
         String searchURL = BASE_SEARCH_URL + showName.getQueryString();
 
         logger.fine("About to download search results from " + searchURL);
@@ -76,8 +90,12 @@ public class TheTVDBProvider {
     }
 
     private static String getShowListingXml(final Show show)
-        throws TVRenamerIOException
+        throws TVRenamerIOException, DiscontinuedApiException
     {
+        if (apiIsDeprecated) {
+            throw new DiscontinuedApiException();
+        }
+
         Integer showId = show.getId();
         if (showId == null) {
             throw new TVRenamerIOException("cannot download listings for show "
@@ -125,8 +143,25 @@ public class TheTVDBProvider {
         }
     }
 
+    private static synchronized boolean isApiDiscontinuedError(Throwable e) {
+        if (apiIsDeprecated) {
+            return true;
+        }
+        if (0 > LocalDate.now().compareTo(SUNSET)) {
+            return false;
+        }
+        while (e != null) {
+            if (e instanceof FileNotFoundException) {
+                apiIsDeprecated = true;
+                return true;
+            }
+            e = e.getCause();
+        }
+        return false;
+    }
+
     public static void getShowOptions(final ShowName showName)
-        throws TVRenamerIOException
+        throws TVRenamerIOException, DiscontinuedApiException
     {
         DocumentBuilder bld;
         try {
@@ -144,7 +179,11 @@ public class TheTVDBProvider {
         } catch (TVRenamerIOException tve) {
             String msg  = "error parsing XML from " + searchXml + " for series "
                 + showName.getFoundName();
-            logger.log(Level.WARNING, msg, tve);
+            if (isApiDiscontinuedError(tve)) {
+                throw new DiscontinuedApiException();
+            } else {
+                logger.log(Level.WARNING, msg, tve);
+            }
             throw new TVRenamerIOException(msg, tve);
         }
     }

--- a/src/main/org/tvrenamer/controller/UpdateChecker.java
+++ b/src/main/org/tvrenamer/controller/UpdateChecker.java
@@ -40,7 +40,7 @@ public class UpdateChecker {
      * @return true if a new version is available, false if there is no new version or
      *          if an error has occurred
      */
-    private static synchronized boolean isUpdateAvailable() {
+    public static synchronized boolean isUpdateAvailable() {
         if (newVersionAvailable == null) {
             newVersionAvailable = checkIfUpdateAvailable();
         }

--- a/src/main/org/tvrenamer/model/DiscontinuedApiException.java
+++ b/src/main/org/tvrenamer/model/DiscontinuedApiException.java
@@ -1,0 +1,4 @@
+package org.tvrenamer.model;
+
+public class DiscontinuedApiException extends IllegalStateException {
+}

--- a/src/main/org/tvrenamer/model/ShowName.java
+++ b/src/main/org/tvrenamer/model/ShowName.java
@@ -101,7 +101,7 @@ public class ShowName {
         private void nameResolved(Show show) {
             synchronized (listeners) {
                 for (ShowInformationListener informationListener : listeners) {
-                    informationListener.downloaded(show);
+                    informationListener.downloadSucceeded(show);
                 }
             }
         }
@@ -112,6 +112,13 @@ public class ShowName {
                 for (ShowInformationListener informationListener : listeners) {
                     informationListener.downloadFailed(show);
                 }
+            }
+        }
+
+        // see ShowName.apiDiscontinued for documentation
+        private void apiDiscontinued() {
+            synchronized (listeners) {
+                listeners.forEach(ShowInformationListener::apiHasBeenDeprecated);
             }
         }
 
@@ -243,6 +250,17 @@ public class ShowName {
     public void nameNotFound(Show show) {
         synchronized (queryString) {
             queryString.nameNotFound(show);
+        }
+    }
+
+    /**
+     * Notify registered interested parties that the provider is unusable
+     * due to a discontinued API.
+     *
+     */
+    public void apiDiscontinued() {
+        synchronized (queryString) {
+            queryString.apiDiscontinued();
         }
     }
 

--- a/src/main/org/tvrenamer/model/ShowStore.java
+++ b/src/main/org/tvrenamer/model/ShowStore.java
@@ -201,7 +201,7 @@ public class ShowStore {
             if (show.isLocalShow()) {
                 listener.downloadFailed(show);
             } else {
-                listener.downloaded(show);
+                listener.downloadSucceeded(show);
             }
         }
     }
@@ -232,6 +232,9 @@ public class ShowStore {
             try {
                 TheTVDBProvider.getShowOptions(showName);
                 thisShow = showName.selectShowOption();
+            } catch (DiscontinuedApiException e) {
+                showName.apiDiscontinued();
+                return false;
             } catch (TVRenamerIOException e) {
                 thisShow = showName.getFailedShow(e);
             }

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -146,6 +146,12 @@ public class Constants {
     public static final String NO_NEW_VERSION_TITLE = "No New Version Available";
     public static final String NO_NEW_VERSION_AVAILABLE = "There is no new version available\n\n"
         + "Please check the website (" + TVRENAMER_PROJECT_URL + ") for any news or check back later.";
+    public static final String GET_UPDATE_MESSAGE = "This version of TVRenamer is no longer "
+        + "functional.  There is a new version available, which should work. "
+        + TO_DOWNLOAD;
+    public static final String NEED_UPDATE = "This version of TVRenamer is no longer "
+        + "functional.  There is a not currently a new version available, but please "
+        + "check\n" + TVRENAMER_PROJECT_URL + "\nto see when one becomes available.";
 
     public static final String ERROR_PARSING_XML = "Error parsing XML";
     public static final String ERROR_PARSING_NUMBERS = ERROR_PARSING_XML


### PR DESCRIPTION
The provider detects a deprecated API in the following case:
- today's date is later than the designated (hard-coded) sunset date of the API
- we get an exception that is caused by a FileNotFoundException

When we detect a deprecated API, we set a static variable, and then decline to attempt to do any more lookups.

Add a new Exception type, DiscontinuedApiException, that the provider can throw when it detects a detected API.  It continues to throw them for any subsequent calls.

Modify ShowInformationListener to have a new callback, apiHasBeenDeprecated.  Also, while here, change callback name from "downloaded" to "downloadSucceeded", so that it has a unique name that can easily be grepped for.

In ShowStore, catch the DiscontinuedApiException, and call apiHasBeenDeprecated on any listeners (via a call into the ShowName).

In UIStarter, the first time apiHasBeenDeprecated gets called, we put up a dialog box informing the user of the situation.  We also set a static variable so that we don't try to do any more calls, or show any more dialog boxes, after the first one.

Expose method isUpdateAvailable in UpdateChecker, to determine the message we present to the user when it's been detected that the API is deprecated.  If there is an update available, we suggest the user go download it, whereas if there's none available, we just suggest the "check back" later.  (Use new values in Constants.java for these messages).

Add similar functionality to TheTVDBProviderTest.  We need to create a stand-in show in the API deprecated case, to conform with Java expectations that the value of a Future will not be null.