### PR TITLE
Add EpisodePlacement

### DIFF
--- a/etc/idea/files/misc.xml
+++ b/etc/idea/files/misc.xml
@@ -12,8 +12,6 @@
       <entry_point TYPE="method" FQNAME="org.tvrenamer.model.Show void indexEpisodesBySeason()" />
       <entry_point TYPE="method" FQNAME="org.tvrenamer.model.ShowStore org.tvrenamer.model.Show getOrAddShow(java.lang.String filenameShow, java.lang.String actualName)" />
       <entry_point TYPE="method" FQNAME="org.tvrenamer.model.ShowName boolean hasShowOptions()" />
-      <entry_point TYPE="method" FQNAME="org.tvrenamer.model.FileEpisode int getSeasonNum()" />
-      <entry_point TYPE="method" FQNAME="org.tvrenamer.model.FileEpisode int getEpisodeNum()" />
       <entry_point TYPE="method" FQNAME="org.tvrenamer.model.FileEpisode java.lang.String getFilenameSeason()" />
       <entry_point TYPE="method" FQNAME="org.tvrenamer.model.FileEpisode java.lang.String getFilenameEpisode()" />
       <entry_point TYPE="method" FQNAME="org.tvrenamer.model.FileEpisode java.lang.String getFilenameResolution()" />

--- a/src/main/org/tvrenamer/controller/FilenameParser.java
+++ b/src/main/org/tvrenamer/controller/FilenameParser.java
@@ -96,8 +96,7 @@ public class FilenameParser {
                 String foundName = matcher.group(1);
                 ShowName.lookupShowName(foundName);
                 episode.setFilenameShow(foundName);
-                episode.setFilenameSeason(matcher.group(2));
-                episode.setFilenameEpisode(matcher.group(3));
+                episode.setEpisodePlacement(matcher.group(2), matcher.group(3));
                 episode.setFilenameResolution(resolution);
                 episode.setParsed();
 

--- a/src/main/org/tvrenamer/model/Episode.java
+++ b/src/main/org/tvrenamer/model/Episode.java
@@ -26,10 +26,8 @@ public class Episode {
     // This object does not have an opinion of its place within the series ordering.
     // It does serve as a useful place to hang information about such questions, as
     // we do, below.  But it's up to the Show to decide what the "real" answer is.
-    private final Integer airSeasonNumber;
-    private final Integer airEpisodeNumber;
-    private final Integer dvdSeasonNumber;
-    private final Integer dvdEpisodeNumber;
+    private final EpisodePlacement airPlacement;
+    private final EpisodePlacement dvdPlacement;
 
     public Episode(EpisodeInfo info) {
         title = info.episodeName;
@@ -38,11 +36,34 @@ public class Episode {
         airDateString = info.firstAired;
 
         // stringToInt handles null or empty values ok
-        airSeasonNumber = StringUtils.stringToInt(info.seasonNumber);
-        dvdSeasonNumber = StringUtils.stringToInt(info.dvdSeason);
+        final Integer airSeasonNumber = StringUtils.stringToInt(info.seasonNumber);
+        final Integer airEpisodeNumber = StringUtils.stringToInt(info.episodeNumber);
+        final Integer dvdSeasonNumber = StringUtils.stringToInt(info.dvdSeason);
+        final Integer dvdEpisodeNumber = StringUtils.stringToInt(info.dvdEpisodeNumber);
 
-        airEpisodeNumber = StringUtils.stringToInt(info.episodeNumber);
-        dvdEpisodeNumber = StringUtils.stringToInt(info.dvdEpisodeNumber);
+        if (airSeasonNumber == null) {
+            logger.warning("episode \"" + title + "\" does not have an integer season ("
+                           + info.seasonNumber + ")");
+            airPlacement = null;
+        } else if (airEpisodeNumber == null) {
+            logger.info("episode \"" + title + "\" does not have an integer episode number ("
+                        + info.episodeNumber + ")");
+            airPlacement = null;
+        } else {
+            airPlacement = new EpisodePlacement(airSeasonNumber, airEpisodeNumber);
+        }
+
+        if (dvdSeasonNumber == null) {
+            logger.finer("episode \"" + title + "\" does not have an integer DVD season ("
+                         + info.dvdSeason + ")");
+            dvdPlacement = null;
+        } else if (dvdEpisodeNumber == null) {
+            logger.fine("episode \"" + title + "\" does not have an integer DVD episode number ("
+                        + info.dvdEpisodeNumber + ")");
+            dvdPlacement = null;
+        } else {
+            dvdPlacement = new EpisodePlacement(dvdSeasonNumber, dvdEpisodeNumber);
+        }
     }
 
     public String getTitle() {
@@ -72,20 +93,12 @@ public class Episode {
         return firstAired;
     }
 
-    public Integer getSeasonNumber() {
-        return airSeasonNumber;
+    public EpisodePlacement getAirEpisodePlacement() {
+        return airPlacement;
     }
 
-    public Integer getEpisodeNumber() {
-        return airEpisodeNumber;
-    }
-
-    public Integer getDvdSeasonNumber() {
-        return dvdSeasonNumber;
-    }
-
-    public Integer getDvdEpisodeNumber() {
-        return dvdEpisodeNumber;
+    public EpisodePlacement getDvdEpisodePlacement() {
+        return dvdPlacement;
     }
 
     // "Package-private".  Used by Show; should not be used by other classes.

--- a/src/main/org/tvrenamer/model/EpisodePlacement.java
+++ b/src/main/org/tvrenamer/model/EpisodePlacement.java
@@ -1,0 +1,11 @@
+package org.tvrenamer.model;
+
+public class EpisodePlacement {
+    public final int season;
+    public final int episode;
+
+    public EpisodePlacement(int season, int episode) {
+        this.season = season;
+        this.episode = episode;
+    }
+}

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -116,7 +116,7 @@ public class Show extends ShowOption {
      */
     private void addEpisodeToSeason(Episode episode, EpisodePlacement placement) {
         // Check to see if there's already an existing episode.  Only applies if we
-        // have a valid season number and episode number.
+        // have a valid placement.
         Map<Integer, Episode> season = seasons.get(placement.season);
         if (season == null) {
             season = new ConcurrentHashMap<>();
@@ -204,7 +204,7 @@ public class Show extends ShowOption {
     /**
      * Log a message about each episode of this Show for which we found a problem.
      * Generally a "problem" means that we have found two (or more) episodes with
-     * the same season and episode information.  Another problem could be that we
+     * the same placement information.  Another problem could be that we
      * got a null episodeInfo, though there's very little information we can give,
      * in that case.
      *
@@ -258,12 +258,12 @@ public class Show extends ShowOption {
      * Creates Episodes, and adds them to this Show, for each of the given EpisodeInfos.
      * Relies on addOneEpisode() to create and verify the episode.  Collects failures
      * from addOneEpisode(), and logs messages about them.  Generally a "problem" means
-     * that we have found two (or more) episodes with the same season and episode
+     * that we have found two (or more) episodes with the same placement
      * information.  Another problem could be that we got a null episodeInfo, though
      * there's very little information we can give, in that case.
      *
-     * After all the episodes are added, creates an index of the episodes by season and
-     * episode number, according to the current numbering scheme.
+     * After all the episodes are added, creates an index of the episodes by their
+     * placement in the current ordering.
      *
      * @param infos
      *    an array containing information about the episodes, downloaded from the provider
@@ -281,32 +281,30 @@ public class Show extends ShowOption {
     }
 
     /**
-     * Look up an episode for the given season and episode of this show.
+     * Look up an episode for the given placement of this show.
      * Returns null if no such episode was found.
      *
-     * Note that the value this returns is dependent on the numbering scheme
+     * Note that the value this returns is dependent on the ordering
      * in use.  There is not always a definitive answer for which episode goes
      * in which spot.
      *
      * In the future, we may be able to expand it so that we use other
      * meta-information to try to determine which episode a given filename
-     * refers to.  For now, we just go with season number and episode number.
+     * refers to.  For now, we just go with the episode placement.
      *
-     * @param seasonNum
-     *           the season of the episode to return
-     * @param episodeNum
-     *           the episode, within the given season, of the episode to return
-     * @return the episode indexed at the given season and episode of this show.
+     * @param placement
+     *           the placement of the episode to return
+     * @return the episode indexed at the given placement of this show.
      *    Null if no such episode was found.
      */
-    public Episode getEpisode(int seasonNum, int episodeNum) {
-        Map<Integer, Episode> season = seasons.get(seasonNum);
+    public Episode getEpisode(EpisodePlacement placement) {
+        Map<Integer, Episode> season = seasons.get(placement.season);
         if (season == null) {
-            logger.fine("no season " + seasonNum + " found for show " + name);
+            logger.fine("no season " + placement.season + " found for show " + name);
             return null;
         }
-        Episode episode = season.get(episodeNum);
-        logger.fine("for season " + seasonNum + ", episode " + episodeNum
+        Episode episode = season.get(placement.episode);
+        logger.fine("for season " + placement.season + ", episode " + placement.episode
                     + ", found " + episode);
 
         return episode;
@@ -330,6 +328,7 @@ public class Show extends ShowOption {
      *
      * @return a count of how many episodes we have for this Show
      */
+    @SuppressWarnings("BooleanMethodIsAlwaysInverted")
     public boolean hasEpisodes() {
         return (episodes.size() > 0);
     }

--- a/src/main/org/tvrenamer/model/ShowName.java
+++ b/src/main/org/tvrenamer/model/ShowName.java
@@ -362,7 +362,7 @@ public class ShowName {
      *
      * @return a Show, if this ShowName is matched to one.  Null if not.
      */
-    synchronized ShowOption getMatchedShow() {
+    public synchronized ShowOption getMatchedShow() {
         return queryString.getMatchedShow();
     }
 

--- a/src/test/org/tvrenamer/controller/FilenameParserTest.java
+++ b/src/test/org/tvrenamer/controller/FilenameParserTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import org.tvrenamer.model.EpisodePlacement;
 import org.tvrenamer.model.EpisodeTestData;
 import org.tvrenamer.model.FileEpisode;
 
@@ -21,18 +22,20 @@ import java.util.List;
  * identifies the show name, we normalize it somewhat.  We replace punctuation
  * and lower-case the name.
  *
+ * We refer to the season/episode combination as the episode "placement".
+ *
  * The method "testParseFileName" in this file tests that functionality.  Each
- * line of the test input has a filename, and the expected values for show
- * name, season number, episode number, and resolution.  The method parses
- * the filename and verifies the values are as expected.
+ * line of the test input has a filename, and the expected values for show name,
+ * placement, and resolution.  The method parses the filename and verifies the
+ * values are as expected.
  *
  * The next step is to take the normalized string and send it to the
  * provider to try to figure out which show this is actually referring to.
  * The provider might return any number of results, including zero.  If
  * it returns more than one, we try to select the right one.
  *
- * Once we have identified the actual show, then we use the season and
- * episode information to look up the actual episode.
+ * Once we have identified the actual show, then we use the placement
+ * information to look up the actual episode.
  *
  * The method testDownloadAndRename tests the second and third steps.  The
  * static data provided includes the expected episode title, and the test
@@ -894,6 +897,7 @@ public class FilenameParserTest {
             String input = testInput.inputFilename;
             FileEpisode retval = new FileEpisode(input);
             FilenameParser.parseFilename(retval);
+            EpisodePlacement retPlacement = retval.getEpisodePlacement();
 
             assertTrue("unable to parse:<[" + input + "]>",
                        retval.wasParsed());
@@ -901,9 +905,9 @@ public class FilenameParserTest {
                          testInput.filenameShow, retval.getFilenameShow());
 
             assertEquals("On input:<[" + input + "]>, for season,",
-                         Integer.parseInt(testInput.seasonNumString), retval.getSeasonNum());
+                         Integer.parseInt(testInput.seasonNumString), retPlacement.season);
             assertEquals("On input:<[" + input + "]>, for episode,",
-                         Integer.parseInt(testInput.episodeNumString), retval.getEpisodeNum());
+                         Integer.parseInt(testInput.episodeNumString), retPlacement.episode);
             assertEquals("On input:<[" + input + "]>, for resolution,",
                          testInput.episodeResolution, retval.getFilenameResolution());
         }

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -174,19 +174,22 @@ public class TheTVDBProviderTest {
             queryString = actualName;
         }
         final ShowName showName = ShowName.lookupShowName(queryString);
+        ShowOption best = showName.getMatchedShow();
 
-        try {
-            TheTVDBProvider.getShowOptions(showName);
-        } catch (DiscontinuedApiException api) {
-            fail("API deprecation discovered getting show options for " + queryString);
-        } catch (Exception e) {
-            fail("exception getting show options for " + queryString);
+        if (best == null) {
+            try {
+                TheTVDBProvider.getShowOptions(showName);
+            } catch (DiscontinuedApiException api) {
+                fail("API deprecation discovered getting show options for " + queryString);
+            } catch (Exception e) {
+                fail("exception getting show options for " + queryString);
+            }
+            assertTrue("got no options on showName <[" + showName.getFoundName()
+                       + "]> (from input <[" + queryString + "]>)",
+                       showName.hasShowOptions());
+
+            best = showName.selectShowOption();
         }
-        assertTrue("got no options on showName <[" + showName.getFoundName()
-                   + "]> (from input <[" + queryString + "]>)",
-                   showName.hasShowOptions());
-
-        final ShowOption best = showName.selectShowOption();
         assertEquals("resolved show name <[" + showName.getFoundName() + "]> to wrong series;",
                      actualName, best.getName());
 
@@ -198,7 +201,9 @@ public class TheTVDBProviderTest {
         assertEquals("got wrong series ID for <[" + actualName + "]>;",
                      epdata.showId, String.valueOf(series.getId()));
 
-        TheTVDBProvider.getSeriesListing(series);
+        if (!series.hasEpisodes()) {
+            TheTVDBProvider.getSeriesListing(series);
+        }
 
         final Episode ep = series.getEpisode(epdata.seasonNum, epdata.episodeNum);
         if (ep == null) {

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -1048,8 +1048,7 @@ public class FileEpisodeTest {
 
         FileEpisode episode = new FileEpisode(pathstring);
         episode.setFilenameShow(data.filenameShow);
-        episode.setFilenameSeason(data.seasonNumString);
-        episode.setFilenameEpisode(data.episodeNumString);
+        episode.setEpisodePlacement(data.seasonNumString, data.episodeNumString);
         episode.setFilenameResolution(data.episodeResolution);
 
         Show show = ShowStore.getOrAddShow(data.filenameShow, data.properShowName);


### PR DESCRIPTION
An episode "placement" is just its season number and episode number; i.e., the "place" it belongs in the episode index.  It is just a way to encapsulate the two pieces of information.

Use EpisodePlacement in a few places instead of individual season and episode numbers.

Eliminate seasonNum and episodeNum from FileEpisode, in favor of using EpisodePlacement.  And then just deal with all the fanout from that.  Modify comments to refer to placements rather than season/episode, mostly in Show, FilenameParserTest, and FileEpisode.