### PR TITLE
Process both orderings, DVD and air

### DIFF
--- a/src/main/org/tvrenamer/model/Episode.java
+++ b/src/main/org/tvrenamer/model/Episode.java
@@ -93,12 +93,11 @@ public class Episode {
         return firstAired;
     }
 
-    public EpisodePlacement getAirEpisodePlacement() {
+    public EpisodePlacement getEpisodePlacement(boolean useDvd) {
+        if (useDvd) {
+            return dvdPlacement;
+        }
         return airPlacement;
-    }
-
-    public EpisodePlacement getDvdEpisodePlacement() {
-        return dvdPlacement;
     }
 
     // "Package-private".  Used by Show; should not be used by other classes.

--- a/src/main/org/tvrenamer/model/EpisodeOptions.java
+++ b/src/main/org/tvrenamer/model/EpisodeOptions.java
@@ -1,0 +1,114 @@
+package org.tvrenamer.model;
+
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ *
+ * It is useful to remember the context of what this program does, and how there is a slight
+ * mismatch against the model of TheTvDb.
+ *
+ * What TheTvDb does is more natural.  Given a particular episode of the series, where does it
+ * fit in the ordering?  And TheTvDb may give two answers.  One is where it was originally aired.
+ * The other is where it appears in the DVD releases.  There frequently is a difference.
+ *
+ * Let's look at a couple of episodes of Futurama as an example.
+ *
+ * Title                    Aired      DVD
+ * =====                    ======     ======
+ * A Leela of Her Own       S04E10     S03E16
+ * The Why of Fry           S05E08     S04E10
+ *
+ * So, if you know you have "A Leela of Her Own", it could be either S04E10 or S03E16, depending
+ * on what ordering you want to use.
+ *
+ * But this program works a bit differently.  We look at the filename, and extract the season and
+ * episode information.  Based on that information, we decide which episode it is, so we can
+ * add the episode title to the filename.  So, the question is not, "Where does 'The Why of Fry'
+ * fit in?".  It is, "What is S04E10 of Futurama?"  And as we can see, there can be two answers,
+ * depending on which ordering is being used.
+ *
+ * Theoretically, there could be more than two answers.  Even for a given ordering, the DB could
+ * potentially assign the same season number and episode number to two distinct episodes.
+ * It probably SHOULDN'T ever happen, but we're prepared to handle it if it does.
+ *
+ * We use a class called EpisodeOptions which ties together an episode and an ordering.
+ * The EpisodeNumber objects are indexed into the Season; each index has a list.  So, using the
+ * Futurama example, if we just added those two episodes, we'd have:
+ *    Season 3:  16: {DVD: A Leela of Her Own}
+ *    Season 4:  10: {DVD: The Why of Fry}, {AIR: A Leela of Her Own}
+ *    Season 5:   8: {AIR: The Why of Fry}
+ *
+ */
+class EpisodeOptions {
+
+    private static final class EpisodeNumber {
+        final boolean isDvd;
+        final Episode episode;
+
+        EpisodeNumber(boolean isDvd, Episode episode) {
+            this.isDvd = isDvd;
+            this.episode = episode;
+        }
+
+        @Override
+        public String toString() {
+            return (isDvd ? "DVD: " : "air: ") + episode.getTitle();
+        }
+    }
+
+    private final List<EpisodeNumber> episodeList = new LinkedList<>();
+
+    /**
+     *
+     * @param isDvd
+     *           whether or not the placement is the DVD ordering
+     * @param episode
+     *           the episode to add at the given index
+     */
+    public void addEpisode(boolean isDvd, Episode episode) {
+        episodeList.add(new EpisodeNumber(isDvd, episode));
+    }
+
+    /**
+     * Look up an episode in this season in the given ordering.
+     *
+     * @param preferDvd
+     *           whether the caller prefers the DVD ordering, or over-the-air ordering
+     * @return the Episode that best matches the request criteria, or null if none does
+     */
+    public Episode get(boolean preferDvd) {
+        if (episodeList.size() == 0) {
+            return null;
+        }
+
+        return episodeList.stream()
+            .filter(ep -> ep.isDvd == preferDvd)
+            .findFirst()
+            .orElse(episodeList.get(0))
+            .episode;
+    }
+
+    /**
+     * Standard object method to represent this EpisodeOptions as a string.
+     *
+     * @return string version of this
+     */
+    @Override
+    public String toString() {
+        StringBuilder rep = new StringBuilder();
+        rep.append("[");
+        int n = episodeList.size();
+        if (n > 0) {
+            rep.append(episodeList.get(0));
+            if (n > 1) {
+                for (int i=1; i<n; i++) {
+                    rep.append("\n                ");
+                    rep.append(episodeList.get(i));
+                }
+            }
+        }
+        rep.append("]");
+        return rep.toString();
+    }
+}

--- a/src/main/org/tvrenamer/model/Season.java
+++ b/src/main/org/tvrenamer/model/Season.java
@@ -1,0 +1,115 @@
+package org.tvrenamer.model;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.logging.Logger;
+
+/**
+ * Represents a TV show's Season
+ */
+class Season {
+    private static final Logger logger = Logger.getLogger(Season.class.getName());
+
+    private final Show show;
+    private final int seasonNum;
+    private final Map<Integer, Episode> episodes = new ConcurrentHashMap<>();
+
+    /**
+     * Create a Season object.
+     *
+     * Note that the information provided to this constructor is only used for
+     * debugging.  In terms of the actual functionality, there's no reason a
+     * Season needs to know what show it's part of, or which season number
+     * it represents.
+     *
+     * @param show
+     *           the Show to which this Season belongs
+     * @param seasonNum
+     *           the season number that this Season represents
+     */
+    Season(Show show, int seasonNum) {
+        this.show = show;
+        this.seasonNum = seasonNum;
+    }
+
+    /**
+     * Look up an episode in this season.
+     *
+     * Nothing in the Season class knows anything about Episodes.  The caller
+     * decides where to place the Episode, and this method just returns what
+     * has been placed there.  It does not investigate the values contained
+     * within the episode.
+     *
+     * @param episodeNum
+     *           the episode number, within this Season, of the episode to return
+     * @return the episode found at the requested place
+     */
+    public Episode get(int episodeNum) {
+        Episode found = episodes.get(episodeNum);
+        logger.fine("for season " + seasonNum + ", episode " + episodeNum
+                    + ", found " + found);
+        return found;
+    }
+
+    /**
+     * Add an episode to a season's index of episodes.
+     *
+     * This method does not interpret or validate the episode number in any
+     * way.  The number may correspond to the Episode's DVD ordering, or its
+     * over-the-air ordering, or really neither, if the caller wants.  The
+     * caller can choose to put any episode in any slot.
+     *
+     * @param episode
+     *           the episode to add at the given index
+     * @param episodeNum
+     *           the episode, of this season, of the episode to add
+     */
+    public void addEpisode(Episode episode, int episodeNum) {
+        if (episode == null) {
+            logger.warning("can not add null episode");
+            return;
+        }
+
+        Episode found = episodes.remove(episodeNum);
+
+        if (found == null) {
+            // This is the expected case; we should only be adding the episode to
+            // the index a single time.
+            episodes.put(episodeNum, episode);
+        } else if (found == episode) {
+            // Well, this is unfortunate; if it happens, investigate why.  But it's
+            // fine.  We still have a unique object.  No action required.
+            episodes.put(episodeNum, episode);
+        } else if (found.getTitle().equals(episode.getTitle())) {
+            // This is less fine.  We've apparently created two objects to represent
+            // the same data.  This should be fixed.
+            logger.warning("replacing episode " + found.getEpisodeId()
+                           + " for show " + show.getName() + ", season "
+                           + seasonNum + ", episode " + episodeNum + " (\""
+                           + found.getTitle() + "\") with " + episode.getEpisodeId());
+            episodes.put(episodeNum, episode);
+        } else {
+            // In this very unexpected case, we will not keep EITHER episode
+            // in the table.  Remember that both will be in the unordered List
+            // of episodes.  A future feature may be that when an episode is not
+            // found in the seasons map, for whatever reason, to search through
+            // the episode list.  This could be for "special" episodes, DVD extras,
+            // etc.  But it could also be used for this case.
+            logger.warning("two episodes found for show " + show.getName() + ", season "
+                           + seasonNum + ", episode " + episodeNum + ": \""
+                           + found.getTitle() + "\" (" + found.getEpisodeId() + ") and \""
+                           + episode.getTitle() + "\" (" + episode.getEpisodeId() + ")");
+        }
+    }
+
+
+    /**
+     * Standard object method to represent this Season as a string.
+     *
+     * @return string version of this
+     */
+    @Override
+    public String toString() {
+        return "[Season " + seasonNum + " of " + show.getName() + "]";
+    }
+}

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -292,9 +292,18 @@ public class Show extends ShowOption {
             logger.fine("no season " + placement.season + " found for show " + name);
             return null;
         }
-        Episode episode = season.get(placement.episode);
-        logger.fine("for season " + placement.season + ", episode " + placement.episode
-                    + ", found " + episode);
+        Episode episode;
+        synchronized (this) {
+            episode = season.get(placement.episode);
+        }
+        if (episode == null) {
+            logger.warning("could not get episode of " + name + " for season "
+                           + placement.season + ", episode " + placement.episode);
+        } else {
+            logger.fine("for season " + placement.season + ", episode " + placement.episode
+                        + " with ID " + episode.getEpisodeId()
+                        + ", found " + episode);
+        }
 
         return episode;
     }

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -285,6 +285,16 @@ public class TheTVDBProviderTest {
                                       .preferDvd(true)
                                       .episodeTitle("Triple Hot Dog Sandwich on Wheat")
                                       .build());
+        // Now we specify a preference of the non-DVD ordering, S08E13 should
+        // resolve to the other alternative, "Joel Hurwitz Returns"
+        testSeriesNameAndEpisodeTitle(new EpisodeTestData.Builder()
+                                      .properShowName("Robot Chicken")
+                                      .showId("75734")
+                                      .seasonNum(8)
+                                      .episodeNum(13)
+                                      .preferDvd(false)
+                                      .episodeTitle("Joel Hurwitz Returns")
+                                      .build());
         // This is meant to test the "fallback".  We go back to explicitly preferring DVD.
         // But for this placement, there is no DVD entry (as of the time of this writing).
         // Given that there is no DVD episode at the placement, it should "fall back" to
@@ -299,6 +309,28 @@ public class TheTVDBProviderTest {
                                       .episodeNum(15)
                                       .preferDvd(true)
                                       .episodeTitle("Yogurt in a Bag")
+                                      .build());
+        // Now we test S08E14, which was considered a true conflict in earlier versions.
+        // That's because there are two episodes for which their BEST placement was the
+        // same place.  In earlier versions, we "panicked" and put neither episode in
+        // place in the index.  Now that we have the EpisodeOption class, we can store
+        // both and retrieve either on demand.  First, try the over-the-air ordering:
+        testSeriesNameAndEpisodeTitle(new EpisodeTestData.Builder()
+                                      .properShowName("Robot Chicken")
+                                      .showId("75734")
+                                      .seasonNum(8)
+                                      .episodeNum(14)
+                                      .preferDvd(false)
+                                      .episodeTitle("Hopefully Salt")
+                                      .build());
+        // Now, the DVD ordering for S08E14:
+        testSeriesNameAndEpisodeTitle(new EpisodeTestData.Builder()
+                                      .properShowName("Robot Chicken")
+                                      .showId("75734")
+                                      .seasonNum(8)
+                                      .episodeNum(14)
+                                      .preferDvd(true)
+                                      .episodeTitle("Joel Hurwitz Returns")
                                       .build());
     }
 

--- a/src/test/org/tvrenamer/model/EpisodeTestData.java
+++ b/src/test/org/tvrenamer/model/EpisodeTestData.java
@@ -32,6 +32,7 @@ public class EpisodeTestData {
     public final String queryString;
     public final Integer seasonNum;
     public final Integer episodeNum;
+    public final Boolean preferDvd;
 
     // These are attributes we get back from the provider
     public final String properShowName;
@@ -59,6 +60,7 @@ public class EpisodeTestData {
         String queryString;
         Integer seasonNum;
         Integer episodeNum;
+        Boolean preferDvd;
 
         String properShowName;
         String episodeTitle;
@@ -244,6 +246,15 @@ public class EpisodeTestData {
             }
         }
 
+        public Builder preferDvd(boolean val) {
+            if ((preferDvd == null) || (preferDvd == val)) {
+                preferDvd = val;
+            } else {
+                throw new IllegalStateException("cannot re-set preferDvd");
+            }
+            return this;
+        }
+
         public Builder properShowName(String val) {
             if (properShowName == null) {
                 properShowName = val;
@@ -350,6 +361,7 @@ public class EpisodeTestData {
         queryString = builder.queryString;
         seasonNum = builder.getSeasonNum();
         episodeNum = builder.getEpisodeNum();
+        preferDvd = builder.preferDvd;
 
         properShowName = builder.properShowName;
         episodeTitle = builder.episodeTitle;


### PR DESCRIPTION
This is in service of Issue #169.

Let's look at a few episodes of the show _Robot Chicken_.  (I refer to season and episode number information like "S08E14" as a _placement_.)

```
Episode Title         DVD Placement  Aired Placement
==================    =============  ===============
Western Hay Batch     S08E12           S08E11
Triple Hot Dog        S08E13           S08E12
Joel Hurwitz Returns  S08E14           S08E13
Hopefully Salt        (none)           S08E14
Yogurt in a Bag       (none)           S08E15
```

So, if a user has a file, _Robot Chicken S08E14.mp4_, and the renaming rule says we should add the episode title to the filename, which title should we add?

Our answer as of now is it should be the former, simply because we have a blanket policy of "prefer DVD ordering".

So if we **prefer** DVD ordering, should we look only at DVD placement?  No, some shows simply don't have any DVD information.  Not every show gets released on DVD.

But beyond that, many shows -- as the Robot Chicken example shows -- have released some episodes on DVD, but not others.

What if we see _Robot Chicken S08E15.mp4_?  We still prefer DVD ordering, but there is no episode with S08E15 as its DVD placement.  But there is one with S08E15 as its regular placement.  So, we use that one.  We *prefer* an episode that matches the season and episode number in its DVD ordering, but we will fall back on the over-the-air placement, if no episode meets the criteria.

We implement this by building an index.  Previously, the process was:
- we iterate over all known episodes
- if it has a DVD placement, we try adding it to the index at that place
- if it doesn't have DVD placement, we try using the over-the-air placement

So, _Western Hay Batch_ would be entered into the index using its DVD placement, S08E12.  Since _Yogurt in a Bag_ doesn't have a DVD placement, it would be entered at S08E15.

We would try to add _Joel Hurwitz Returns_ to the index at S08E14, it's DVD placement.  As for _Hopefully Salt_, we would try to add it to the index using its **aired** placement, S08E14.

So, there's a conflict.  The behavior as of the previous release was, we'd "panic", log a message about the two conflicting episodes, and put *neither* of them into the index.

Note that such a conflict only happens when two episodes have the same preferred placement, which only happens if one of them has a DVD placement, and the other one doesn't.  It does **NOT** happen every time that the DVD placement disagrees with the over-the-air placement.  For example, _Western Hay Batch_ and _Triple Hot Dog_ both could be mapped to S08E12, but S08E12 is not the **preferred** placement for _Triple Hot Dog_, so there was no conflict.

This commit introduces a class, _EpisodeOptions_.  Now a placement is mapped to an instance of EpisodeOptions, rather than just to a single Episode.

Now when we iterate over every episode in Show, we always add BOTH placements to the index: DVD and over-the-air.  We don't reserve "over-the-air" for a fallback any more.  And we remember which placement is which, because the EpisodeOptions class preserves this information.

Then, when we look up an Episode in a Season, we say whether we prefer the DVD ordering or air ordering.  There is always a "fallback" when doing a get.  You will get the ordering you asked for, if such an episode is there, but will get one from the other ordering if your requested ordering doesn't have an episode.

As of now, in the application, we only _get_ with a DVD preference, but that may change in a future commit.  (We are already able to get non-DVD episodes in the test harness.)

So, going back to our example:
- this ensures a deterministic answer for S08E14: it will be the DVD S08E14, because that's currently the preference
- this also ensures a deterministic answer for S08E15: it will be the air S08E15, because no DVD S08E15 exists
- we now have functionality to extract _Hopefully Salt_ as S08E14; it just isn't yet exposed to the user

The code would allow the same episode to be the only episode mapped at two different places in the index.  It also would allow multiple episodes with the same placement even with the same ordering.  Neither of these things should ever happen.  But the code doesn't check for it, and is prepared to handle it, if that's the data we get from the provider.