### PR TITLE
#289 A digit followed by a capital letter is a word break

### DIFF
--- a/src/main/org/tvrenamer/controller/util/StringUtils.java
+++ b/src/main/org/tvrenamer/controller/util/StringUtils.java
@@ -167,6 +167,9 @@ public class StringUtils {
         // transform "CamelCaps" => "Camel Caps"
         rval = rval.replaceAll("(\\p{Lower})([\\p{Upper}\\p{Digit}])", "$1 $2");
 
+        // example: "30Rock" => "30 Rock"
+        rval = rval.replaceAll("(\\p{Digit})([\\p{Upper}])", "$1 $2");
+
         // borrowed from http://stackoverflow.com/a/17099039
         // condenses acronyms (".S.H.I.E.L.D." -> " SHIELD")
         rval = rval.replaceAll("(?<=(^|[. ])[\\S&&\\D])[.](?=[\\S&&\\D]([.]|$))", "");

--- a/src/test/org/tvrenamer/controller/util/StringUtilsTest.java
+++ b/src/test/org/tvrenamer/controller/util/StringUtilsTest.java
@@ -181,6 +181,7 @@ public class StringUtilsTest {
         assertEquals("The X Files", StringUtils.replacePunctuation("The X-Files"));
         assertEquals("Myth Busters", StringUtils.replacePunctuation("MythBusters"));
         assertEquals("Blackish", StringUtils.replacePunctuation("Black-ish"));
+        assertEquals("30 Rock", StringUtils.replacePunctuation("30Rock"));
         assertEquals("Mr Robot", StringUtils.replacePunctuation("Mr. Robot"));
         assertEquals("Starving", StringUtils.replacePunctuation("Star-ving"));
         assertEquals("big bang theory", StringUtils.replacePunctuation("big-bang-theory"));


### PR DESCRIPTION
E.g., "30Rock" should become "30 Rock".  This resolves Issue #289 

If we don't do this, and we query for "30rock" instead of "30 rock", the show is not found.

We can't just incorporate this into the camel caps rule, because a digit followed by a digit should not be a word break.

Add a test for this.