### PR TITLE
Present options for DVD or Air on a per-episode basis (#261)

### DIFF
--- a/src/main/org/tvrenamer/model/EpisodeOptions.java
+++ b/src/main/org/tvrenamer/model/EpisodeOptions.java
@@ -2,6 +2,7 @@ package org.tvrenamer.model;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  *
@@ -87,6 +88,26 @@ class EpisodeOptions {
             .findFirst()
             .orElse(episodeList.get(0))
             .episode;
+    }
+
+    /**
+     * Look up episodes for this season and episode number
+     *
+     * @param preferDvd
+     *           whether the caller prefers the DVD ordering, or over-the-air ordering
+     * @return a list of Episodes that possibly match
+     */
+    public List<Episode> getAll(boolean preferDvd) {
+        if (episodeList.size() == 0) {
+            return null;
+        }
+
+        return episodeList.stream()
+            .sorted((e1, e2) -> ((e1.isDvd == preferDvd) ? 0 : 1) -
+                    ((e2.isDvd == preferDvd) ? 0 : 1))
+            .map(ep -> ep.episode)
+            .distinct()
+            .collect(Collectors.toList());
     }
 
     /**

--- a/src/main/org/tvrenamer/model/Season.java
+++ b/src/main/org/tvrenamer/model/Season.java
@@ -1,5 +1,6 @@
 package org.tvrenamer.model;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Logger;
@@ -56,6 +57,24 @@ class Season {
         logger.fine("for season " + seasonNum + ", episode " + episodeNum
                     + ", found " + found);
         return found;
+    }
+
+    /**
+     * Look up an episode in this season in the given ordering.
+     *
+     * @param preferDvd
+     *           whether the caller prefers the DVD ordering, or over-the-air ordering
+     * @param episodeNum
+     *           the episode number, within this Season, of the episode to return
+     * @return the Episodes that match the request criteria, or null if none does
+     */
+    public List<Episode> getAll(boolean preferDvd, int episodeNum) {
+        EpisodeOptions options = episodes.get(episodeNum);
+        if (options == null) {
+            return null;
+        }
+
+        return options.getAll(preferDvd);
     }
 
     /**

--- a/src/main/org/tvrenamer/model/Show.java
+++ b/src/main/org/tvrenamer/model/Show.java
@@ -306,6 +306,24 @@ public class Show extends ShowOption {
     }
 
     /**
+     * Look up episodes for the given season and episode of this show.
+     * Returns null if no such episode was found.
+     *
+     * @param placement
+     *           the placement of the episode to return
+     * @return the episodes indexed at the given season and episode of this show.
+     *    Null if no such episode was found.
+     */
+    public List<Episode> getEpisodes(EpisodePlacement placement) {
+        Season season = seasons.get(placement.season);
+        if (season == null) {
+            logger.warning("no season " + placement.season + " found for show " + name);
+            return null;
+        }
+        return season.getAll(preferDvd, placement.episode);
+    }
+
+    /**
      * Find out whether or not there are seasons associated with this show.
      * Generally this indicates that the show's listings have been downloaded,
      * the episodes have been organized into seasons, and the show is ready to go.

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -22,6 +22,7 @@ import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowLayout;
 import org.eclipse.swt.widgets.Button;
+import org.eclipse.swt.widgets.Combo;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Control;
 import org.eclipse.swt.widgets.DirectoryDialog;
@@ -509,6 +510,21 @@ public final class UIStarter implements Observer, AddEpisodeListener {
         return rval;
     }
 
+    private void setComboBoxProposedDest(final TableItem item,
+                                        final FileEpisode ep,
+                                        final List<String> options)
+    {
+        final Combo combo = new Combo(resultsTable, SWT.DROP_DOWN | SWT.READ_ONLY);
+        options.forEach(combo::add);
+        combo.setText(options.get(0));
+        combo.addModifyListener(e -> ep.setChosenEpisode(combo.getSelectionIndex()));
+        item.setData(combo);
+
+        final TableEditor editor = new TableEditor(resultsTable);
+        editor.grabHorizontal = true;
+        editor.setEditor(combo, item, NEW_FILENAME_COLUMN);
+    }
+
     /**
      * Fill in the value for the "Proposed File" column of the given row, with the text
      * we get from the given episode.  This is the only method that should ever set
@@ -521,7 +537,29 @@ public final class UIStarter implements Observer, AddEpisodeListener {
      *    the FileEpisode to use to obtain the text
      */
     private void setProposedDestColumn(final TableItem item, final FileEpisode ep) {
-        item.setText(NEW_FILENAME_COLUMN, ep.getReplacementText());
+        final Object itemData = item.getData();
+        if (itemData != null) {
+            final Control oldCombo = (Control) itemData;
+            if (!oldCombo.isDisposed()) {
+                oldCombo.dispose();
+            }
+        }
+
+        int count = 0;
+        final List<String> options = ep.getReplacementText();
+        if (options != null) {
+            count = options.size();
+        }
+        if (count == 0) {
+            item.setText(NEW_FILENAME_COLUMN, ADDED_PLACEHOLDER_FILENAME);
+            return;
+        }
+
+        if (count == 1) {
+            item.setText(NEW_FILENAME_COLUMN, options.get(0));
+        } else {
+            setComboBoxProposedDest(item, ep, options);
+        }
     }
 
     private void listingsDownloaded(TableItem item, FileEpisode episode) {

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -206,7 +206,9 @@ public class TheTVDBProviderTest {
             TheTVDBProvider.getSeriesListing(series);
         }
 
-        final Episode ep = series.getEpisode(new EpisodePlacement(epdata.seasonNum, epdata.episodeNum));
+        final EpisodePlacement placement = new EpisodePlacement(epdata.seasonNum, epdata.episodeNum);
+        final List<Episode> allEps = series.getEpisodes(placement);
+        final Episode ep = allEps.get(0);
         if (ep == null) {
             fail("result of calling getEpisode(" + epdata.seasonNum + ", " + epdata.episodeNum
                  + ") on " + actualName + " came back null");

--- a/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
+++ b/src/test/org/tvrenamer/controller/TheTVDBProviderTest.java
@@ -698,11 +698,8 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    // @BeforeClass
-    @SuppressWarnings("unused")
+    @BeforeClass
     public static void setupValues29() {
-        // Comment this out because Offspring has three untitled episodes with
-        // the same placement, but different IDs
         values.add(new EpisodeTestData.Builder()
                    .queryString("offspring")
                    .properShowName("Offspring")
@@ -723,11 +720,8 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    // @BeforeClass
-    @SuppressWarnings("unused")
+    @BeforeClass
     public static void setupValues31() {
-        // Comment this out because Robot Chicken has a conflict between DVD
-        // and regular numbering.
         values.add(new EpisodeTestData.Builder()
                    .queryString("robot chicken")
                    .properShowName("Robot Chicken")
@@ -770,11 +764,8 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    // @BeforeClass
-    @SuppressWarnings("unused")
+    @BeforeClass
     public static void setupValues35() {
-        // Comment this out because the episode listing for The Good Wife
-        // currently (2017/06/02) comes through unparsable.
         values.add(new EpisodeTestData.Builder()
                    .queryString("the good wife")
                    .properShowName("The Good Wife")
@@ -784,8 +775,7 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    // @BeforeClass
-    @SuppressWarnings("unused")
+    @BeforeClass
     public static void setupValues36() {
         // Trying options for "the walking dead" gives a "Series Not Permitted".
         // We issue a warning, but it's not really a problem.
@@ -996,11 +986,8 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    // @BeforeClass
-    @SuppressWarnings("unused")
+    @BeforeClass
     public static void setupValues55() {
-        // Comment this out because "strike back" apparently no longer
-        // resolves to the correct show.
         values.add(new EpisodeTestData.Builder()
                    .queryString("strike back")
                    .properShowName("Strike Back")
@@ -1076,11 +1063,8 @@ public class TheTVDBProviderTest {
                    .build());
     }
 
-    // @BeforeClass
-    @SuppressWarnings("unused")
+    @BeforeClass
     public static void setupValues62() {
-        // Comment this out because "Lucifer" has conflicting special episodes
-        // (season "0", episode "2")
         values.add(new EpisodeTestData.Builder()
                    .queryString("lucifer")
                    .properShowName("Lucifer")

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -1088,7 +1088,7 @@ public class FileEpisodeTest {
                 assertEquals("suffix fail on " + data.inputFilename,
                              data.filenameSuffix, episode.getFilenameSuffix());
                 assertEquals("test which " + data.documentation,
-                             data.expectedReplacement, episode.getRenamedBasename());
+                             data.expectedReplacement, episode.getRenamedBasename(0));
             } catch (Exception e) {
                 verboseFail("testing " + data, e);
             }


### PR DESCRIPTION
For show/placement specifications which have different valid values for DVD and Air ordering, have the UI use the DVD as the default, but make the table cell a combo box that allows the user to choose the alternate episode.
