### PR TITLE
Issue #305: Change indexing scheme for duplicate files

### DIFF
--- a/src/main/org/tvrenamer/controller/FileMover.java
+++ b/src/main/org/tvrenamer/controller/FileMover.java
@@ -246,6 +246,15 @@ public class FileMover implements Callable<Boolean> {
     }
 
     /**
+     * Add a version string to the destination filename.
+     *
+     * @return destination filename with a version added
+     */
+    private String addVersionString() {
+        return destBasename + VERSION_SEPARATOR_STRING + destIndex + destSuffix;
+    }
+
+    /**
      * Check/verify numerous things, and if everything is as it should be,
      * execute the move.
      *
@@ -277,7 +286,7 @@ public class FileMover implements Callable<Boolean> {
             if (userPrefs.isMoveEnabled()) {
                 destDir = destRoot.resolve(DUPLICATES_DIRECTORY);
             }
-            filename = destBasename + VERSION_SEPARATOR_STRING + destIndex + destSuffix;
+            filename = addVersionString();
         }
 
         if (!FileUtilities.ensureWritableDirectory(destDir)) {

--- a/src/main/org/tvrenamer/controller/FileMover.java
+++ b/src/main/org/tvrenamer/controller/FileMover.java
@@ -251,7 +251,7 @@ public class FileMover implements Callable<Boolean> {
      * @return destination filename with a version added
      */
     private String addVersionString() {
-        return destBasename + VERSION_SEPARATOR_STRING + destIndex + destSuffix;
+        return destBasename + " (" + destIndex + ")" + destSuffix;
     }
 
     /**

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -168,7 +168,6 @@ public class Constants {
     public static final String DEFAULT_REPLACEMENT_MASK = "%S [%sx%0e] %t";
     public static final String DEFAULT_SEASON_PREFIX = "Season ";
     public static final String DEFAULT_IGNORED_KEYWORD = "sample";
-    public static final String VERSION_SEPARATOR_STRING = "~";
     public static final String DUPLICATES_DIRECTORY = "versions";
     public static final String DEFAULT_LANGUAGE = "en";
 


### PR DESCRIPTION
Previously, we had renamed files as:
 `<basename>~2.<suffix>`

Now it will be:
 `<basename> (2).<suffix>`
