### PR TITLE
Delete combo box along with table row, and cleanup

### DIFF
--- a/etc/checks.xml
+++ b/etc/checks.xml
@@ -29,7 +29,7 @@
             <property name="max" value="110"/>
         </module>
         <module name="MethodLength">
-            <property name="max" value="115"/>
+            <property name="max" value="78"/>
         </module>
         <module name="OneTopLevelClass"/>
         <module name="NoLineWrap"/>

--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -124,12 +124,8 @@ public class UserPreferences extends Observable {
                 }
             }
         }
-        if (Files.notExists(CONFIGURATION_DIRECTORY)) {
-            try {
-                Files.createDirectories(CONFIGURATION_DIRECTORY);
-            } catch (Exception e) {
-                throw new RuntimeException("Could not create configuration directory");
-            }
+        if (!FileUtilities.ensureWritableDirectory(CONFIGURATION_DIRECTORY)) {
+            throw new RuntimeException("Could not create configuration directory");
         }
         if (temp != null) {
             try {

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -84,14 +84,19 @@ public class Constants {
     public static final String GENERAL_LABEL = "General";
     public static final String RENAMING_LABEL = "Renaming";
     public static final String MOVE_ENABLED_TEXT = "Move Enabled [?]";
+    public static final String RENAME_ENABLED_TEXT = "Rename Enabled [?]";
     public static final String DEST_DIR_TEXT = "TV Directory [?]";
     public static final String DEST_DIR_BUTTON_TEXT = "Select directory";
     public static final String DIR_DIALOG_TEXT = "Please select a directory and click OK";
     public static final String SEASON_PREFIX_TEXT = "Season Prefix [?]";
     public static final String SEASON_PREFIX_ZERO_TEXT = "Season Prefix Leading Zero [?]";
     public static final String IGNORE_LABEL_TEXT = "Ignore files containing [?]";
-    public static final String RECURSE_FOLDERS_TEXT = "Recursively add shows in subdirectories";
-    public static final String CHECK_UPDATES_TEXT = "Check for Updates at startup";
+    public static final String RECURSE_FOLDERS_TEXT = "Recursively add shows in subdirectories [?]";
+    public static final String RECURSE_FOLDERS_TOOLTIP = "If unchecked, do not look into subfolders "
+        + "for shows to add";
+    public static final String CHECK_UPDATES_TEXT = "Check for Updates at startup [?]";
+    public static final String CHECK_UPDATES_TOOLTIP = "If checked, will automatically check "
+        + APPLICATION_NAME + " website for new versions at startup, and offer to update if found";
     public static final String RENAME_TOKEN_TEXT = "Rename Tokens [?]";
     public static final String RENAME_FORMAT_TEXT = "Rename Format [?]";
     public static final String RENAME_ENABLED_TOOLTIP = "Whether the 'rename' functionality is enabled.\n"

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -191,6 +191,42 @@ class PreferencesDialog extends Dialog {
         preferencesShell.redraw();
     }
 
+    private void createLabel(final String label, final String tooltip, final Composite group) {
+        final Label labelObj = new Label(group, SWT.NONE);
+        labelObj.setText(label);
+        labelObj.setToolTipText(tooltip);
+
+        // we don't need to return the object
+    }
+
+    private Text createText(final String text, final Composite group, boolean setSize) {
+        final Text textObj = new Text(group, SWT.BORDER);
+        textObj.setText(text);
+        textObj.setTextLimit(99);
+        GridData layout;
+        if (setSize) {
+            layout = new GridData(GridData.FILL, GridData.CENTER, true, true, 2, 1);
+        } else {
+            layout = new GridData(GridData.FILL, GridData.CENTER, true, true);
+        }
+        textObj.setLayoutData(layout);
+
+        return textObj;
+    }
+
+    private Button createCheckbox(final String text, final String tooltip,
+                                  final boolean isChecked, final Composite group,
+                                  final int alignment, final int span)
+    {
+        final Button box = new Button(group, SWT.CHECK);
+        box.setText(text);
+        box.setSelection(isChecked);
+        box.setLayoutData(new GridData(alignment, GridData.CENTER, true, true, span, 1));
+        box.setToolTipText(tooltip);
+
+        return box;
+    }
+
     private Button createDestDirButton(Composite group) {
         final Button button = new Button(group, SWT.PUSH);
         button.setText(DEST_DIR_BUTTON_TEXT);
@@ -210,72 +246,30 @@ class PreferencesDialog extends Dialog {
     }
 
     private void populateGeneralTab(final Composite generalGroup) {
-        moveEnabledCheckbox = new Button(generalGroup, SWT.CHECK);
-        moveEnabledCheckbox.setText(MOVE_ENABLED_TEXT);
-        moveEnabledCheckbox.setSelection(prefs.isMoveEnabled());
-        moveEnabledCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
-                                                       true, true, 2, 1));
-        moveEnabledCheckbox.setToolTipText(MOVE_ENABLED_TOOLTIP);
+        moveEnabledCheckbox = createCheckbox(MOVE_ENABLED_TEXT, MOVE_ENABLED_TOOLTIP,
+                                             prefs.isMoveEnabled(), generalGroup, GridData.BEGINNING, 2);
+        renameEnabledCheckbox = createCheckbox(RENAME_ENABLED_TEXT, RENAME_ENABLED_TOOLTIP,
+                                               prefs.isRenameEnabled(), generalGroup, GridData.END, 1);
 
-        renameEnabledCheckbox = new Button(generalGroup, SWT.CHECK);
-        renameEnabledCheckbox.setText(RENAME_ENABLED_TEXT);
-        renameEnabledCheckbox.setSelection(prefs.isRenameEnabled());
-        renameEnabledCheckbox.setLayoutData(new GridData(GridData.END, GridData.CENTER,
-                                                         true, true, 1, 1));
-        renameEnabledCheckbox.setToolTipText(RENAME_ENABLED_TOOLTIP);
-
-        Label destDirLabel = new Label(generalGroup, SWT.NONE);
-        destDirLabel.setText(DEST_DIR_TEXT);
-        destDirLabel.setToolTipText(DEST_DIR_TOOLTIP);
-
-        destDirText = new Text(generalGroup, SWT.BORDER);
-        destDirText.setText(prefs.getDestinationDirectoryName());
-        destDirText.setTextLimit(99);
-        destDirText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, true));
-
+        createLabel(DEST_DIR_TEXT, DEST_DIR_TOOLTIP, generalGroup);
+        destDirText = createText(prefs.getDestinationDirectoryName(), generalGroup, false);
         destDirButton = createDestDirButton(generalGroup);
 
-        Label seasonPrefixLabel = new Label(generalGroup, SWT.NONE);
-        seasonPrefixLabel.setText(SEASON_PREFIX_TEXT);
-        seasonPrefixLabel.setToolTipText(PREFIX_TOOLTIP);
+        createLabel(SEASON_PREFIX_TEXT, PREFIX_TOOLTIP, generalGroup);
+        seasonPrefixText = createText(prefs.getSeasonPrefixForDisplay(), generalGroup, true);
+        seasonPrefixLeadingZeroCheckbox = createCheckbox(SEASON_PREFIX_ZERO_TEXT, SEASON_PREFIX_ZERO_TOOLTIP,
+                                                         prefs.isSeasonPrefixLeadingZero(),
+                                                         generalGroup, GridData.BEGINNING, 3);
 
-        seasonPrefixText = new Text(generalGroup, SWT.BORDER);
-        seasonPrefixText.setText(prefs.getSeasonPrefixForDisplay());
-        seasonPrefixText.setTextLimit(99);
-        seasonPrefixText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER,
-                                                    true, true, 2, 1));
+        createLabel(IGNORE_LABEL_TEXT, IGNORE_LABEL_TOOLTIP, generalGroup);
+        ignoreWordsText = createText(prefs.getIgnoredKeywordsString(), generalGroup, false);
 
-        seasonPrefixLeadingZeroCheckbox = new Button(generalGroup, SWT.CHECK);
-        seasonPrefixLeadingZeroCheckbox.setText(SEASON_PREFIX_ZERO_TEXT);
-        seasonPrefixLeadingZeroCheckbox.setSelection(prefs.isSeasonPrefixLeadingZero());
-        seasonPrefixLeadingZeroCheckbox.setLayoutData(new GridData(GridData.BEGINNING,
-                                                                   GridData.CENTER,
-                                                                   true, true, 3, 1));
-        seasonPrefixLeadingZeroCheckbox.setToolTipText(SEASON_PREFIX_ZERO_TOOLTIP);
-
-        Label ignoreLabel = new Label(generalGroup, SWT.NONE);
-        ignoreLabel.setText(IGNORE_LABEL_TEXT);
-        ignoreLabel.setToolTipText(IGNORE_LABEL_TOOLTIP);
-
-        ignoreWordsText = new Text(generalGroup, SWT.BORDER);
-        String ignoreWords = prefs.getIgnoredKeywordsString();
-        ignoreWordsText.setText(ignoreWords);
-        ignoreWordsText.setTextLimit(99);
-        ignoreWordsText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, true));
-
-        recurseFoldersCheckbox = new Button(generalGroup, SWT.CHECK);
-        recurseFoldersCheckbox.setText(RECURSE_FOLDERS_TEXT);
-        recurseFoldersCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
-                                                          true, true, 3, 1));
-        recurseFoldersCheckbox.setSelection(prefs.isRecursivelyAddFolders());
-        recurseFoldersCheckbox.setToolTipText(RECURSE_FOLDERS_TOOLTIP);
-
-        checkForUpdatesCheckbox = new Button(generalGroup, SWT.CHECK);
-        checkForUpdatesCheckbox.setText(CHECK_UPDATES_TEXT);
-        checkForUpdatesCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
-                                                           true, true, 3, 1));
-        checkForUpdatesCheckbox.setSelection(prefs.checkForUpdates());
-        checkForUpdatesCheckbox.setToolTipText(CHECK_UPDATES_TOOLTIP);
+        recurseFoldersCheckbox = createCheckbox(RECURSE_FOLDERS_TEXT, RECURSE_FOLDERS_TOOLTIP,
+                                                prefs.isRecursivelyAddFolders(), generalGroup,
+                                                GridData.BEGINNING, 3);
+        checkForUpdatesCheckbox = createCheckbox(CHECK_UPDATES_TEXT, CHECK_UPDATES_TOOLTIP,
+                                                 prefs.checkForUpdates(), generalGroup,
+                                                 GridData.BEGINNING, 3);
     }
 
     private void createGeneralTab(final TabFolder tabFolder) {
@@ -335,11 +329,7 @@ class PreferencesDialog extends Dialog {
         episodeTitleLabel.setText(RENAME_FORMAT_TEXT);
         episodeTitleLabel.setToolTipText(RENAME_FORMAT_TOOLTIP);
 
-        replacementStringText = new Text(replacementGroup, SWT.BORDER);
-        replacementStringText.setText(prefs.getRenameReplacementString());
-        replacementStringText.setTextLimit(99);
-        replacementStringText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER,
-                                                         true, true, 2, 1));
+        replacementStringText = createText(prefs.getRenameReplacementString(), replacementGroup, true);
 
         createDragSource(renameTokensList);
         createDropTarget(replacementStringText);

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -218,7 +218,7 @@ class PreferencesDialog extends Dialog {
         moveEnabledCheckbox.setToolTipText(MOVE_ENABLED_TOOLTIP);
 
         renameEnabledCheckbox = new Button(generalGroup, SWT.CHECK);
-        renameEnabledCheckbox.setText("Rename Enabled [?]");
+        renameEnabledCheckbox.setText(RENAME_ENABLED_TEXT);
         renameEnabledCheckbox.setSelection(prefs.isRenameEnabled());
         renameEnabledCheckbox.setLayoutData(new GridData(GridData.END, GridData.CENTER,
                                                          true, true, 1, 1));
@@ -268,12 +268,14 @@ class PreferencesDialog extends Dialog {
         recurseFoldersCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
                                                           true, true, 3, 1));
         recurseFoldersCheckbox.setSelection(prefs.isRecursivelyAddFolders());
+        recurseFoldersCheckbox.setToolTipText(RECURSE_FOLDERS_TOOLTIP);
 
         checkForUpdatesCheckbox = new Button(generalGroup, SWT.CHECK);
         checkForUpdatesCheckbox.setText(CHECK_UPDATES_TEXT);
         checkForUpdatesCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
                                                            true, true, 3, 1));
         checkForUpdatesCheckbox.setSelection(prefs.checkForUpdates());
+        checkForUpdatesCheckbox.setToolTipText(CHECK_UPDATES_TOOLTIP);
     }
 
     private void createGeneralTab(final TabFolder tabFolder) {

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -121,6 +121,7 @@ class PreferencesDialog extends Dialog {
     private Button moveEnabledCheckbox;
     private Button renameEnabledCheckbox;
     private Text destDirText;
+    private Button destDirButton;
     private Text seasonPrefixText;
     private Button seasonPrefixLeadingZeroCheckbox;
     private Text replacementStringText;
@@ -208,15 +209,7 @@ class PreferencesDialog extends Dialog {
         return button;
     }
 
-    private void createGeneralTab(TabFolder tabFolder) {
-        TabItem item = new TabItem(tabFolder, SWT.NULL);
-        item.setText(GENERAL_LABEL);
-
-        Composite generalGroup= new Composite(tabFolder, SWT.NONE);
-        generalGroup.setLayout(new GridLayout(3, false));
-        generalGroup.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true, 3, 1));
-        generalGroup.setToolTipText(GENERAL_TOOLTIP);
-
+    private void populateGeneralTab(final Composite generalGroup) {
         moveEnabledCheckbox = new Button(generalGroup, SWT.CHECK);
         moveEnabledCheckbox.setText(MOVE_ENABLED_TEXT);
         moveEnabledCheckbox.setSelection(prefs.isMoveEnabled());
@@ -240,7 +233,7 @@ class PreferencesDialog extends Dialog {
         destDirText.setTextLimit(99);
         destDirText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, true));
 
-        final Button destDirButton = createDestDirButton(generalGroup);
+        destDirButton = createDestDirButton(generalGroup);
 
         Label seasonPrefixLabel = new Label(generalGroup, SWT.NONE);
         seasonPrefixLabel.setText(SEASON_PREFIX_TEXT);
@@ -259,16 +252,6 @@ class PreferencesDialog extends Dialog {
                                                                    GridData.CENTER,
                                                                    true, true, 3, 1));
         seasonPrefixLeadingZeroCheckbox.setToolTipText(SEASON_PREFIX_ZERO_TOOLTIP);
-
-        toggleEnableControls(moveEnabledCheckbox, destDirText, destDirButton, seasonPrefixText);
-
-        moveEnabledCheckbox.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                toggleEnableControls(moveEnabledCheckbox, destDirText,
-                                     destDirButton, seasonPrefixText);
-            }
-        });
 
         Label ignoreLabel = new Label(generalGroup, SWT.NONE);
         ignoreLabel.setText(IGNORE_LABEL_TEXT);
@@ -291,6 +274,27 @@ class PreferencesDialog extends Dialog {
         checkForUpdatesCheckbox.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
                                                            true, true, 3, 1));
         checkForUpdatesCheckbox.setSelection(prefs.checkForUpdates());
+    }
+
+    private void createGeneralTab(final TabFolder tabFolder) {
+        final TabItem item = new TabItem(tabFolder, SWT.NULL);
+        item.setText(GENERAL_LABEL);
+
+        final Composite generalGroup = new Composite(tabFolder, SWT.NONE);
+        generalGroup.setLayout(new GridLayout(3, false));
+        generalGroup.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true, 3, 1));
+        generalGroup.setToolTipText(GENERAL_TOOLTIP);
+
+        populateGeneralTab(generalGroup);
+
+        toggleEnableControls(moveEnabledCheckbox, destDirText, destDirButton, seasonPrefixText);
+        moveEnabledCheckbox.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                toggleEnableControls(moveEnabledCheckbox, destDirText,
+                                     destDirButton, seasonPrefixText);
+            }
+        });
 
         item.setControl(generalGroup);
     }

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -177,6 +177,18 @@ class PreferencesDialog extends Dialog {
         createActionButtonGroup();
     }
 
+    /**
+     * Toggle whether the or not the listed {@link Control}s are enabled, based off the of
+     * the selection value of the checkbox
+     * @param decidingCheckbox the checkbox the enable flag is taken off
+     * @param controls the list of controls to update
+     */
+    private void toggleEnableControls(Button decidingCheckbox, Control... controls) {
+        for (Control control : controls) {
+            control.setEnabled(decidingCheckbox.getSelection());
+        }
+        preferencesShell.redraw();
+    }
 
     private void createGeneralTab(TabFolder tabFolder) {
         TabItem item = new TabItem(tabFolder, SWT.NULL);
@@ -403,18 +415,5 @@ class PreferencesDialog extends Dialog {
         UIUtils.checkDestinationDirectory(prefs);
 
         UserPreferences.store(prefs);
-    }
-
-    /**
-     * Toggle whether the or not the listed {@link Control}s are enabled, based off the of
-     * the selection value of the checkbox
-     * @param decidingCheckbox the checkbox the enable flag is taken off
-     * @param controls the list of controls to update
-     */
-    private void toggleEnableControls(Button decidingCheckbox, Control... controls) {
-        for (Control control : controls) {
-            control.setEnabled(decidingCheckbox.getSelection());
-        }
-        preferencesShell.redraw();
     }
 }

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -190,6 +190,24 @@ class PreferencesDialog extends Dialog {
         preferencesShell.redraw();
     }
 
+    private Button createDestDirButton(Composite group) {
+        final Button button = new Button(group, SWT.PUSH);
+        button.setText(DEST_DIR_BUTTON_TEXT);
+        button.addListener(SWT.Selection, event -> {
+            DirectoryDialog directoryDialog = new DirectoryDialog(preferencesShell);
+
+            directoryDialog.setFilterPath(prefs.getDestinationDirectoryName());
+            directoryDialog.setText(DIR_DIALOG_TEXT);
+
+            String dir = directoryDialog.open();
+            if (dir != null) {
+                destDirText.setText(dir);
+            }
+        });
+
+        return button;
+    }
+
     private void createGeneralTab(TabFolder tabFolder) {
         TabItem item = new TabItem(tabFolder, SWT.NULL);
         item.setText(GENERAL_LABEL);
@@ -222,19 +240,7 @@ class PreferencesDialog extends Dialog {
         destDirText.setTextLimit(99);
         destDirText.setLayoutData(new GridData(GridData.FILL, GridData.CENTER, true, true));
 
-        final Button destDirButton = new Button(generalGroup, SWT.PUSH);
-        destDirButton.setText(DEST_DIR_BUTTON_TEXT);
-        destDirButton.addListener(SWT.Selection, event -> {
-            DirectoryDialog directoryDialog = new DirectoryDialog(preferencesShell);
-
-            directoryDialog.setFilterPath(prefs.getDestinationDirectoryName());
-            directoryDialog.setText(DIR_DIALOG_TEXT);
-
-            String dir = directoryDialog.open();
-            if (dir != null) {
-                destDirText.setText(dir);
-            }
-        });
+        final Button destDirButton = createDestDirButton(generalGroup);
 
         Label seasonPrefixLabel = new Label(generalGroup, SWT.NONE);
         seasonPrefixLabel.setText(SEASON_PREFIX_TEXT);

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -82,9 +82,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     private Display display;
     private List<String> ignoreKeywords;
 
-    private Button addFilesButton;
-    private Button addFolderButton;
-    private Button clearFilesButton;
     private Button renameSelectedButton;
     private Table swtTable;
     private ProgressBar totalProgressBar;
@@ -167,28 +164,50 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         }
     }
 
-    private void setupClearFilesButton() {
+    private void setupTopButtons() {
+        final Composite topButtonsComposite = new Composite(shell, SWT.FILL);
+        topButtonsComposite.setLayout(new RowLayout());
+
+        final FileDialog fd = new FileDialog(shell, SWT.MULTI);
+        final Button addFilesButton = new Button(topButtonsComposite, SWT.PUSH);
+        addFilesButton.setText("Add files");
+        addFilesButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                String pathPrefix = fd.open();
+                if (pathPrefix != null) {
+                    episodeMap.addFilesToQueue(pathPrefix, fd.getFileNames());
+                }
+            }
+        });
+
+        final DirectoryDialog dd = new DirectoryDialog(shell, SWT.SINGLE);
+        final Button addFolderButton = new Button(topButtonsComposite, SWT.PUSH);
+        addFolderButton.setText("Add Folder");
+        addFolderButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                String directory = dd.open();
+                if (directory != null) {
+                    // load all of the files in the dir
+                    episodeMap.addFolderToQueue(directory);
+                }
+            }
+
+        });
+
+        final Button clearFilesButton = new Button(topButtonsComposite, SWT.PUSH);
+        clearFilesButton.setText("Clear List");
         clearFilesButton.addSelectionListener(new SelectionAdapter() {
             public void widgetSelected(SelectionEvent e) {
                 deleteAllTableItems();
             }
         });
+
+        setupUpdateStuff(topButtonsComposite);
     }
 
     private void setupMainWindow() {
-        final Composite topButtonsComposite = new Composite(shell, SWT.FILL);
-        topButtonsComposite.setLayout(new RowLayout());
-
-        addFilesButton = new Button(topButtonsComposite, SWT.PUSH);
-        addFilesButton.setText("Add files");
-
-        addFolderButton = new Button(topButtonsComposite, SWT.PUSH);
-        addFolderButton.setText("Add Folder");
-
-        clearFilesButton = new Button(topButtonsComposite, SWT.PUSH);
-        clearFilesButton.setText("Clear List");
-
-        setupUpdateStuff(topButtonsComposite);
         setupResultsTable();
         setupTableDragDrop();
 
@@ -294,34 +313,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         helpVisitWebPageItem.addSelectionListener(new UrlLauncher(TVRENAMER_PROJECT_URL));
 
         return helpMenu;
-    }
-
-    private void setupAddFilesDialog() {
-        final FileDialog fd = new FileDialog(shell, SWT.MULTI);
-        addFilesButton.addSelectionListener(new SelectionAdapter() {
-
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                String pathPrefix = fd.open();
-                if (pathPrefix != null) {
-                    episodeMap.addFilesToQueue(pathPrefix, fd.getFileNames());
-                }
-            }
-        });
-
-        final DirectoryDialog dd = new DirectoryDialog(shell, SWT.SINGLE);
-        addFolderButton.addSelectionListener(new SelectionAdapter() {
-
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                String directory = dd.open();
-                if (directory != null) {
-                    // load all of the files in the dir
-                    episodeMap.addFolderToQueue(directory);
-                }
-            }
-
-        });
     }
 
     private void setupSelectionListener() {
@@ -878,9 +869,8 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         this.display = ui.display;
         prefs = UserPreferences.getInstance();
 
+        setupTopButtons();
         setupMainWindow();
-        setupAddFilesDialog();
-        setupClearFilesButton();
         setupMenuBar();
     }
 }

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -340,6 +340,49 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         });
     }
 
+    private void setupColumns() {
+        final TableColumn selectedColumn = new TableColumn(swtTable, SWT.LEFT);
+        selectedColumn.setText("Selected");
+        selectedColumn.setWidth(60);
+        selectedColumn.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                sortTable(selectedColumn, SELECTED_COLUMN);
+            }
+        });
+
+        final TableColumn sourceColumn = new TableColumn(swtTable, SWT.LEFT);
+        sourceColumn.setText("Current File");
+        sourceColumn.setWidth(550);
+        sourceColumn.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                sortTable(sourceColumn, CURRENT_FILE_COLUMN);
+            }
+        });
+
+        final TableColumn destinationColumn = new TableColumn(swtTable, SWT.LEFT);
+        setColumnDestText(destinationColumn);
+        destinationColumn.setWidth(550);
+        destinationColumn.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                sortTable(destinationColumn, NEW_FILENAME_COLUMN);
+            }
+        });
+
+        final TableColumn statusColumn = new TableColumn(swtTable, SWT.LEFT);
+        statusColumn.setText("Status");
+        statusColumn.setWidth(60);
+        statusColumn.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                sortTable(statusColumn, STATUS_COLUMN);
+            }
+        });
+
+    }
+
     private void setupResultsTable() {
         swtTable.setHeaderVisible(true);
         swtTable.setLinesVisible(true);
@@ -349,21 +392,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         gridData.horizontalSpan = 3;
         swtTable.setLayoutData(gridData);
 
-        final TableColumn selectedColumn = new TableColumn(swtTable, SWT.LEFT);
-        selectedColumn.setText("Selected");
-        selectedColumn.setWidth(60);
-
-        final TableColumn sourceColumn = new TableColumn(swtTable, SWT.LEFT);
-        sourceColumn.setText("Current File");
-        sourceColumn.setWidth(550);
-
-        final TableColumn destinationColumn = new TableColumn(swtTable, SWT.LEFT);
-        setColumnDestText(destinationColumn);
-        destinationColumn.setWidth(550);
-
-        final TableColumn statusColumn = new TableColumn(swtTable, SWT.LEFT);
-        statusColumn.setText("Status");
-        statusColumn.setWidth(60);
+        setupColumns();
 
         // Allow deleting of elements
         swtTable.addKeyListener(new KeyAdapter() {
@@ -384,34 +413,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                     default:
                 }
 
-            }
-        });
-
-        selectedColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(selectedColumn, SELECTED_COLUMN);
-            }
-        });
-
-        sourceColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(sourceColumn, CURRENT_FILE_COLUMN);
-            }
-        });
-
-        destinationColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(destinationColumn, NEW_FILENAME_COLUMN);
-            }
-        });
-
-        statusColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(statusColumn, STATUS_COLUMN);
             }
         });
 

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -124,6 +124,47 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         ui.uiCleanup();
     }
 
+    private int getTableItemIndex(TableItem item) {
+        try {
+            return swtTable.indexOf(item);
+        } catch (IllegalArgumentException | SWTException ignored) {
+            // We'll just fall through and return the sentinel.
+        }
+        return ITEM_NOT_IN_TABLE;
+    }
+
+    private void deleteSelectedTableItems() {
+        for (final TableItem item : swtTable.getSelection()) {
+            int index = getTableItemIndex(item);
+            if (ITEM_NOT_IN_TABLE == index) {
+                logger.info("error: somehow selected item not found in table");
+                continue;
+            }
+
+            String filename = item.getText(CURRENT_FILE_COLUMN);
+            episodeMap.remove(filename);
+
+            swtTable.remove(index);
+            item.dispose();
+        }
+        swtTable.deselectAll();
+    }
+
+    private void deleteAllTableItems() {
+        for (final TableItem item : swtTable.getItems()) {
+            episodeMap.remove(item.getText(CURRENT_FILE_COLUMN));
+        }
+        swtTable.removeAll();
+    }
+
+    private void setupClearFilesButton() {
+        clearFilesButton.addSelectionListener(new SelectionAdapter() {
+            public void widgetSelected(SelectionEvent e) {
+                deleteAllTableItems();
+            }
+        });
+    }
+
     private void setupMainWindow() {
         final Composite topButtonsComposite = new Composite(shell, SWT.FILL);
         topButtonsComposite.setLayout(new RowLayout());
@@ -270,14 +311,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                 }
             }
 
-        });
-    }
-
-    private void setupClearFilesButton() {
-        clearFilesButton.addSelectionListener(new SelectionAdapter() {
-            public void widgetSelected(SelectionEvent e) {
-                deleteAllTableItems();
-            }
         });
     }
 
@@ -586,15 +619,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         }
     }
 
-    private int getTableItemIndex(TableItem item) {
-        try {
-            return swtTable.indexOf(item);
-        } catch (IllegalArgumentException | SWTException ignored) {
-            // We'll just fall through and return the sentinel.
-        }
-        return ITEM_NOT_IN_TABLE;
-    }
-
     private boolean tableContainsTableItem(TableItem item) {
         return (ITEM_NOT_IN_TABLE != getTableItemIndex(item));
     }
@@ -653,30 +677,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             }
         }
         return false;
-    }
-
-    private void deleteSelectedTableItems() {
-        for (final TableItem item : swtTable.getSelection()) {
-            int index = getTableItemIndex(item);
-            if (ITEM_NOT_IN_TABLE == index) {
-                logger.info("error: somehow selected item not found in table");
-                continue;
-            }
-
-            String filename = item.getText(CURRENT_FILE_COLUMN);
-            episodeMap.remove(filename);
-
-            swtTable.remove(index);
-            item.dispose();
-        }
-        swtTable.deselectAll();
-    }
-
-    private void deleteAllTableItems() {
-        for (final TableItem item : swtTable.getItems()) {
-            episodeMap.remove(item.getText(CURRENT_FILE_COLUMN));
-        }
-        swtTable.removeAll();
     }
 
     private static String itemDestDisplayedText(final TableItem item) {

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -80,11 +80,11 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     private final UIStarter ui;
     private final Shell shell;
     private final Display display;
+    private final Table swtTable;
     private final EpisodeDb episodeMap = new EpisodeDb();
     private final UserPreferences prefs = UserPreferences.getInstance();
 
     private Button renameSelectedButton;
-    private Table swtTable;
     private ProgressBar totalProgressBar;
     private TaskItem taskItem = null;
 
@@ -343,7 +343,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     }
 
     private void setupResultsTable() {
-        swtTable = new Table(shell, SWT.CHECK | SWT.FULL_SELECTION | SWT.MULTI);
         swtTable.setHeaderVisible(true);
         swtTable.setLinesVisible(true);
         GridData gridData = new GridData(GridData.FILL_BOTH);
@@ -868,6 +867,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         this.display = ui.display;
 
         setupTopButtons();
+        swtTable = new Table(shell, SWT.CHECK | SWT.FULL_SELECTION | SWT.MULTI);
         setupMainWindow();
         setupMenuBar();
     }

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -78,9 +78,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     private static final int ITEM_NOT_IN_TABLE = -1;
 
     private final UIStarter ui;
-    private Shell shell;
-    private Display display;
-    private List<String> ignoreKeywords;
+    private final Shell shell;
+    private final Display display;
+    private final EpisodeDb episodeMap = new EpisodeDb();
 
     private Button renameSelectedButton;
     private Table swtTable;
@@ -88,9 +88,8 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     private TaskItem taskItem = null;
 
     private UserPreferences prefs;
+    private List<String> ignoreKeywords;
     private boolean apiDeprecated = false;
-
-    private final EpisodeDb episodeMap = new EpisodeDb();
 
     void ready() {
         prefs.addObserver(this);

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -202,12 +202,10 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         setupUpdateStuff(topButtonsComposite);
     }
 
-    private void setupMainWindow() {
-        setupResultsTable();
-        setupTableDragDrop();
-
+    private void setupBottomComposite() {
         Composite bottomButtonsComposite = new Composite(shell, SWT.FILL);
         bottomButtonsComposite.setLayout(new GridLayout(3, false));
+
         GridData bottomButtonsCompositeGridData = new GridData(SWT.FILL, SWT.CENTER, true, false, 3, 1);
         bottomButtonsComposite.setLayoutData(bottomButtonsCompositeGridData);
 
@@ -217,9 +215,33 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         quitButtonGridData.widthHint = 70;
         quitButton.setLayoutData(quitButtonGridData);
         quitButton.setText(QUIT_LABEL);
+        quitButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                quit();
+            }
+        });
 
         totalProgressBar = new ProgressBar(bottomButtonsComposite, SWT.SMOOTH);
         totalProgressBar.setLayoutData(new GridData(SWT.FILL, SWT.CENTER, true, true));
+
+        renameSelectedButton = new Button(bottomButtonsComposite, SWT.PUSH);
+        GridData renameSelectedButtonGridData = new GridData(GridData.END, GridData.CENTER, false, false);
+        renameSelectedButton.setLayoutData(renameSelectedButtonGridData);
+        setRenameButtonText(renameSelectedButton);
+        renameSelectedButton.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                renameFiles();
+            }
+        });
+
+    }
+
+    private void setupMainWindow() {
+        setupResultsTable();
+        setupTableDragDrop();
+        setupBottomComposite();
 
         TaskBar taskBar = display.getSystemTaskBar();
         if (taskBar != null) {
@@ -228,26 +250,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                 taskItem = taskBar.getItem(null);
             }
         }
-
-        renameSelectedButton = new Button(bottomButtonsComposite, SWT.PUSH);
-        GridData renameSelectedButtonGridData = new GridData(GridData.END, GridData.CENTER, false, false);
-        renameSelectedButton.setLayoutData(renameSelectedButtonGridData);
-
-        setRenameButtonText(renameSelectedButton);
-
-        renameSelectedButton.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                renameFiles();
-            }
-        });
-
-        quitButton.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                quit();
-            }
-        });
     }
 
     private void makeMenuItem(Menu parent, String text, Listener listener, char shortcut) {

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -81,13 +81,13 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     private final Shell shell;
     private final Display display;
     private final EpisodeDb episodeMap = new EpisodeDb();
+    private final UserPreferences prefs = UserPreferences.getInstance();
 
     private Button renameSelectedButton;
     private Table swtTable;
     private ProgressBar totalProgressBar;
     private TaskItem taskItem = null;
 
-    private UserPreferences prefs;
     private List<String> ignoreKeywords;
     private boolean apiDeprecated = false;
 
@@ -866,7 +866,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         this.ui = ui;
         this.shell = ui.shell;
         this.display = ui.display;
-        prefs = UserPreferences.getInstance();
 
         setupTopButtons();
         setupMainWindow();

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -157,12 +157,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         swtTable.deselectAll();
     }
 
-    private void deleteAllTableItems() {
-        for (final TableItem item : swtTable.getItems()) {
-            deleteTableItem(item);
-        }
-    }
-
     private void setupTopButtons() {
         final Composite topButtonsComposite = new Composite(shell, SWT.FILL);
         topButtonsComposite.setLayout(new RowLayout());
@@ -199,7 +193,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         clearFilesButton.setText("Clear List");
         clearFilesButton.addSelectionListener(new SelectionAdapter() {
             public void widgetSelected(SelectionEvent e) {
-                deleteAllTableItems();
+                for (final TableItem item : swtTable.getItems()) {
+                    deleteTableItem(item);
+                }
             }
         });
 

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -133,28 +133,38 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         return ITEM_NOT_IN_TABLE;
     }
 
+    private void deleteItemCombo(final TableItem item) {
+        final Object itemData = item.getData();
+        if (itemData != null) {
+            final Control oldCombo = (Control) itemData;
+            if (!oldCombo.isDisposed()) {
+                oldCombo.dispose();
+            }
+        }
+    }
+
+    private void deleteTableItem(final TableItem item) {
+        deleteItemCombo(item);
+        episodeMap.remove(item.getText(CURRENT_FILE_COLUMN));
+        item.dispose();
+    }
+
     private void deleteSelectedTableItems() {
         for (final TableItem item : swtTable.getSelection()) {
             int index = getTableItemIndex(item);
+            deleteTableItem(item);
+
             if (ITEM_NOT_IN_TABLE == index) {
                 logger.info("error: somehow selected item not found in table");
-                continue;
             }
-
-            String filename = item.getText(CURRENT_FILE_COLUMN);
-            episodeMap.remove(filename);
-
-            swtTable.remove(index);
-            item.dispose();
         }
         swtTable.deselectAll();
     }
 
     private void deleteAllTableItems() {
         for (final TableItem item : swtTable.getItems()) {
-            episodeMap.remove(item.getText(CURRENT_FILE_COLUMN));
+            deleteTableItem(item);
         }
-        swtTable.removeAll();
     }
 
     private void setupClearFilesButton() {
@@ -484,13 +494,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
      *    the FileEpisode to use to obtain the text
      */
     private void setProposedDestColumn(final TableItem item, final FileEpisode ep) {
-        final Object itemData = item.getData();
-        if (itemData != null) {
-            final Control oldCombo = (Control) itemData;
-            if (!oldCombo.isDisposed()) {
-                oldCombo.dispose();
-            }
-        }
+        deleteItemCombo(item);
 
         if (ep.hasOptions()) {
             final List<String> options = ep.getReplacementOptions();

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -789,6 +789,10 @@ public class FileEpisodeTest {
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Firefly S01E04 Shindig")
                    .build());
+    }
+
+    @BeforeClass
+    public static void setupValuesFirefly2() {
         values.add(new EpisodeTestData.Builder()
                    .filenameShow("firefly")
                    .properShowName("Firefly")
@@ -822,10 +826,6 @@ public class FileEpisodeTest {
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Firefly S01E07 Jaynestown")
                    .build());
-    }
-
-    @BeforeClass
-    public static void setupValuesFirefly2() {
         values.add(new EpisodeTestData.Builder()
                    .filenameShow("firefly")
                    .properShowName("Firefly")
@@ -837,6 +837,10 @@ public class FileEpisodeTest {
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Firefly S01E08 Out of Gas")
                    .build());
+    }
+
+    @BeforeClass
+    public static void setupValuesFirefly3() {
         values.add(new EpisodeTestData.Builder()
                    .filenameShow("firefly")
                    .properShowName("Firefly")
@@ -881,6 +885,10 @@ public class FileEpisodeTest {
                    .replacementMask("%S S%0sE%0e %t")
                    .expectedReplacement("Firefly S01E12 The Message")
                    .build());
+    }
+
+    @BeforeClass
+    public static void setupValuesFirefly4() {
         values.add(new EpisodeTestData.Builder()
                    .filenameShow("firefly")
                    .properShowName("Firefly")


### PR DESCRIPTION
Fix a bug, albeit one that was never released.  It had been that if a row had a combo box and the user deleted it, the combo box was left behind.

Now we check for a combo box, and dispose of it if it is there.  Note that we no longer explicitly remove the item from the table.  It seems that the dispose already takes care of that.

Make some other code-style-related changes, particularly to long methods, and change the maximum method length down to 78.