### PR TITLE
improve internal handling of ignore keywords

### DIFF
--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -447,6 +447,32 @@ public class UserPreferences extends Observable {
     }
 
     /**
+     * Sets the ignore keywords, given a string
+     *
+     * @param ignoreWordsString a string which, when parsed, indicate the files
+     *           that should be ignored.  To be acceptable as an "ignore keyword",
+     *           a string must be at least two characters long.
+     */
+    public void setIgnoreKeywords(String ignoreWordsString) {
+        if (valuesAreDifferent(getIgnoredKeywordsString(), ignoreWordsString)) {
+            ignoreKeywords.clear();
+            String[] ignoreWords = ignoreWordsString.split(IGNORE_WORDS_SPLIT_REGEX);
+            for (String ignorable : ignoreWords) {
+                // Be careful not to allow empty string as a "keyword."
+                if (ignorable.length() > 1) {
+                    // TODO: Convert commas into pipes for proper regex, remove periods
+                    ignoreKeywords.add(ignorable);
+                } else {
+                    logger.warning("keywords to ignore must be at least two characters.");
+                    logger.warning("not adding \"" + ignorable + "\"");
+                }
+            }
+
+            preferenceChanged(UserPreference.IGNORE_REGEX);
+        }
+    }
+
+    /**
      * Sets the season prefix
      *
      * @param prefix the prefix for subfolders we would create to hold individual

--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -400,31 +400,6 @@ public class UserPreferences extends Observable {
     }
 
     /**
-     * Sets the ignore keywords
-     *
-     * @param ignoreKeywords a list of strings which indicate a file that
-     *           should be ignored.  To be acceptable as an "ignore keyword",
-     *           a string must be at least two characters long.
-     */
-    public void setIgnoreKeywords(List<String> ignoreKeywords) {
-        if (valuesAreDifferent(this.ignoreKeywords, ignoreKeywords)) {
-            this.ignoreKeywords.clear();
-            for (String ignorable : ignoreKeywords) {
-                // Be careful not to allow empty string as a "keyword."
-                if (ignorable.length() > 1) {
-                    // TODO: Convert commas into pipes for proper regex, remove periods
-                    this.ignoreKeywords.add(ignorable);
-                } else {
-                    logger.warning("keywords to ignore must be at least two characters.");
-                    logger.warning("not adding \"" + ignorable + "\"");
-                }
-            }
-
-            preferenceChanged(UserPreference.IGNORE_REGEX);
-        }
-    }
-
-    /**
      * @return a list of strings that indicate that the presence of that string in
      *         a filename means that we should ignore that file
      */

--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -54,6 +54,30 @@ public class UserPreferences extends Observable {
     }
 
     /**
+     * UserPreferences constructor which ensures we have an ArrayList
+     */
+    private UserPreferences(final UserPreferences first) {
+        super();
+
+        preloadFolder = first.preloadFolder;
+        destDir = first.destDir;
+        seasonPrefix = first.seasonPrefix;
+        seasonPrefixLeadingZero = first.seasonPrefixLeadingZero;
+        moveEnabled = first.moveEnabled;
+        renameEnabled = first.renameEnabled;
+        removeEmptiedDirectories = first.removeEmptiedDirectories;
+        renameReplacementMask = first.renameReplacementMask;
+        checkForUpdates = first.checkForUpdates;
+        recursivelyAddFolders = first.recursivelyAddFolders;
+        ignoreKeywords = new ArrayList<>();
+        if (first.ignoreKeywords != null) {
+            for (String keyword : first.ignoreKeywords) {
+                ignoreKeywords.add(keyword);
+            }
+        }
+    }
+
+    /**
      * @return the singleton UserPreferences instance for this application
      */
     public static UserPreferences getInstance() {
@@ -151,6 +175,16 @@ public class UserPreferences extends Observable {
     }
 
     /**
+     * Save preferences to xml file
+     *
+     * @param prefs the instance to export to XML
+     */
+    public static void store(UserPreferences prefs) {
+        UserPreferencesPersistence.persist(prefs, PREFERENCES_FILE);
+        logger.fine("Successfully saved/updated preferences");
+    }
+
+    /**
      * Load preferences from xml file
      *
      * @return an instance of UserPreferences, expected to be used as the singleton instance
@@ -161,25 +195,23 @@ public class UserPreferences extends Observable {
 
         // retrieve from file and update in-memory copy
         UserPreferences prefs = UserPreferencesPersistence.retrieve(PREFERENCES_FILE);
-
-        if (prefs != null) {
+        if (prefs == null) {
+            prefs = new UserPreferences();
+            store(prefs);
+        } else if (prefs.ignoreKeywords instanceof ArrayList) {
             logger.finer("Successfully read preferences from: " + PREFERENCES_FILE.toAbsolutePath());
             logger.fine("Successfully read preferences: " + prefs.toString());
         } else {
-            prefs = new UserPreferences();
+            // This is to fix a bug where we created UserPreferences with Arrays.asList, which
+            // created an object of a weird type that we couldn't use easily.  Recreate the
+            // UserPreferences object with an ArrayList, and write it out so that we don't
+            // have the same problem next time.
+            prefs = new UserPreferences(prefs);
+            logger.fine("Modified read preferences: " + prefs.toString());
+            store(prefs);
         }
 
         return prefs;
-    }
-
-    /**
-     * Save preferences to xml file
-     *
-     * @param prefs the instance to export to XML
-     */
-    public static void store(UserPreferences prefs) {
-        UserPreferencesPersistence.persist(prefs, PREFERENCES_FILE);
-        logger.fine("Successfully saved/updated preferences");
     }
 
     /**

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -32,7 +32,6 @@ import org.eclipse.swt.widgets.Text;
 import org.tvrenamer.model.ReplacementToken;
 import org.tvrenamer.model.UserPreferences;
 
-import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -405,11 +404,8 @@ class PreferencesDialog extends Dialog {
         prefs.setSeasonPrefix(seasonPrefixText.getText());
         prefs.setSeasonPrefixLeadingZero(seasonPrefixLeadingZeroCheckbox.getSelection());
         prefs.setRenameReplacementString(replacementStringText.getText());
-        String ignoreWordsString = ignoreWordsText.getText();
-        String[] ignoreWords = ignoreWordsString.split(IGNORE_WORDS_SPLIT_REGEX);
-        prefs.setIgnoreKeywords(Arrays.asList(ignoreWords));
+        prefs.setIgnoreKeywords(ignoreWordsText.getText());
         prefs.setRenameEnabled(renameEnabledCheckbox.getSelection());
-
         prefs.setCheckForUpdates(checkForUpdatesCheckbox.getSelection());
         prefs.setRecursivelyAddFolders(recurseFoldersCheckbox.getSelection());
         prefs.setDestinationDirectory(destDirText.getText());


### PR DESCRIPTION
An earlier commit, within this development cycle, changed how we handled "ignoreKeywords" and introduced a bug.

This PR changes is so that the String that the user types into the preferences dialog is actually processed within UserPreferences, rather than in PreferencesDialog.

Add some code to repair the damage done by the bug.