### PR TITLE
Add unparsed episodes to table

### DIFF
--- a/src/main/org/tvrenamer/model/EpisodeDb.java
+++ b/src/main/org/tvrenamer/model/EpisodeDb.java
@@ -56,11 +56,9 @@ public class EpisodeDb implements Observer {
         final FileEpisode episode = new FileEpisode(path);
         episode.setIgnoreReason(ignorableReason(pathname));
         if (!episode.wasParsed()) {
-            // TODO: we can add these episodes to the table anyway,
-            // to provide information to the user, and in the future,
-            // to let them help us parse the filenames.
-            logger.severe("Couldn't parse file: " + pathname);
-            return null;
+            // We're putting the episode in the table anyway, but it's
+            // not much use.  TODO: make better use of it.
+            logger.warning("Couldn't parse file: " + pathname);
         }
         put(pathname, episode);
         return episode;
@@ -106,9 +104,7 @@ public class EpisodeDb implements Observer {
             logger.info("already in table: " + key);
         } else {
             FileEpisode ep = add(key);
-            if (ep != null) {
-                contents.add(ep);
-            }
+            contents.add(ep);
         }
     }
 

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -304,7 +304,7 @@ public class FileEpisode {
         return (parseStatus == ParseStatus.PARSED);
     }
 
-    public int optionCount() {
+    public synchronized int optionCount() {
         if (seriesStatus != SeriesStatus.GOT_LISTINGS) {
             return 0;
         }

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -46,6 +46,7 @@ import org.tvrenamer.controller.ShowInformationListener;
 import org.tvrenamer.controller.ShowListingsListener;
 import org.tvrenamer.controller.UpdateChecker;
 import org.tvrenamer.controller.UrlLauncher;
+import org.tvrenamer.controller.util.StringUtils;
 import org.tvrenamer.model.EpisodeDb;
 import org.tvrenamer.model.FailedShow;
 import org.tvrenamer.model.FileEpisode;
@@ -573,6 +574,10 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         for (final FileEpisode episode : episodes) {
             final String fileName = episode.getFilepath();
             final TableItem item = createTableItem(swtTable, fileName, episode);
+            if (!episode.wasParsed()) {
+                failTableItem(item);
+                continue;
+            }
             synchronized (this) {
                 if (apiDeprecated) {
                     tableItemFailed(item, episode);
@@ -581,6 +586,10 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             }
 
             final String showName = episode.getFilenameShow();
+            if (StringUtils.isBlank(showName)) {
+                logger.fine("no show name found for " + episode);
+                continue;
+            }
             ShowStore.getShow(showName, new ShowInformationListener() {
                     @Override
                     public void downloadSucceeded(Show show) {


### PR DESCRIPTION
Previously, when we couldn't parse a filename (i.e., extract presumed show name, season number, and episode number), we quietly omitted it.

Now, we'll add it to the table.  We already had code to handle it and to display a message that it couldn't be parsed.