### PR TITLE
doesn't make sense to have move and rename both disabled

### DIFF
--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -635,8 +635,9 @@ public class FileEpisode {
         } else if (userPrefs.isMoveEnabled()) {
             replacementOptions.add(getMoveToDirectory() + FILE_SEPARATOR_STRING + fileNameString);
         } else {
-            // This setting doesn't make any sense, but we haven't bothered to
-            // disallow it yet.
+            // This setting is prohibited, and both the UI and the UserPreferences class are set
+            // up to prevent it.  But, if it somehow happens, we always want to fail gracefully.
+            logger.severe("apparently both rename and move are disabled! This is not allowed!");
             replacementOptions.add(fileNameString);
         }
         replacementText = replacementOptions.get(0);

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -179,15 +179,48 @@ class PreferencesDialog extends Dialog {
 
     /**
      * Toggle whether the or not the listed {@link Control}s are enabled, based off the of
-     * the selection value of the checkbox
-     * @param decidingCheckbox the checkbox the enable flag is taken off
+     * the given state value.
+     *
+     * @param state the boolean to set the other controls to
      * @param controls the list of controls to update
      */
-    private void toggleEnableControls(Button decidingCheckbox, Control... controls) {
+    private void toggleEnableControls(boolean state, Control... controls) {
         for (Control control : controls) {
-            control.setEnabled(decidingCheckbox.getSelection());
+            control.setEnabled(state);
         }
         preferencesShell.redraw();
+    }
+
+    private void handleMoveCheckbox(final boolean moveEnabled) {
+        // The terminology here gets confusing.  These are checkboxes which enable or disable
+        // specific functionality.  But we also can enable or disable the checkboxes themselves!
+        // That's what we're doing here.  Because it does not make sense to have "move" and
+        // "rename" both disabled, when one functionality is disabled, we disable the other
+        // check box, so that the user cannot disable the other functionality.
+        if (moveEnabled) {
+            renameEnabledCheckbox.setEnabled(true);
+        } else {
+            // If we are here, the user has disabled move functionality, but unchecking the
+            // "move" checkbox.  Therefore, we need to make sure "rename' stays selected,
+            // unless or until "move" is re-enabled.  The very fact that we got here means,
+            // if things are working properly, that rename is *already* selected.  If it
+            // weren't, the user shouldn't have been able to uncheck "move".  So, the first
+            // line here should be redundant.  But, do it anyway, just in case somehow
+            // there's a bug.
+            renameEnabledCheckbox.setSelection(true);
+            renameEnabledCheckbox.setEnabled(false);
+        }
+        toggleEnableControls(moveEnabled, destDirText, destDirButton, seasonPrefixText);
+    }
+
+    private void handleRenameCheckbox(final boolean renameEnabled) {
+        // See comments in handleMoveCheckbox; all the same logic applies here, as well.
+        if (renameEnabled) {
+            moveEnabledCheckbox.setEnabled(true);
+        } else {
+            moveEnabledCheckbox.setSelection(true);
+            moveEnabledCheckbox.setEnabled(false);
+        }
     }
 
     private void createLabel(final String label, final String tooltip, final Composite group) {
@@ -245,10 +278,16 @@ class PreferencesDialog extends Dialog {
     }
 
     private void populateGeneralTab(final Composite generalGroup) {
+        final boolean moveIsEnabled = prefs.isMoveEnabled();
+        boolean renameIsEnabled = prefs.isRenameEnabled();
+        if (!moveIsEnabled && !renameIsEnabled) {
+            renameIsEnabled = true;
+            prefs.setRenameEnabled(true);
+        }
         moveEnabledCheckbox = createCheckbox(MOVE_ENABLED_TEXT, MOVE_ENABLED_TOOLTIP,
-                                             prefs.isMoveEnabled(), generalGroup, GridData.BEGINNING, 2);
+                                             moveIsEnabled, generalGroup, GridData.BEGINNING, 2);
         renameEnabledCheckbox = createCheckbox(RENAME_ENABLED_TEXT, RENAME_ENABLED_TOOLTIP,
-                                               prefs.isRenameEnabled(), generalGroup, GridData.END, 1);
+                                               renameIsEnabled, generalGroup, GridData.END, 1);
 
         createLabel(DEST_DIR_TEXT, DEST_DIR_TOOLTIP, generalGroup);
         destDirText = createText(prefs.getDestinationDirectoryName(), generalGroup, false);
@@ -269,6 +308,20 @@ class PreferencesDialog extends Dialog {
         checkForUpdatesCheckbox = createCheckbox(CHECK_UPDATES_TEXT, CHECK_UPDATES_TOOLTIP,
                                                  prefs.checkForUpdates(), generalGroup,
                                                  GridData.BEGINNING, 3);
+
+        handleMoveCheckbox(moveIsEnabled);
+        moveEnabledCheckbox.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                handleMoveCheckbox(moveEnabledCheckbox.getSelection());
+            }
+        });
+        renameEnabledCheckbox.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                handleRenameCheckbox(renameEnabledCheckbox.getSelection());
+            }
+        });
     }
 
     private void createGeneralTab(final TabFolder tabFolder) {
@@ -281,15 +334,6 @@ class PreferencesDialog extends Dialog {
         generalGroup.setToolTipText(GENERAL_TOOLTIP);
 
         populateGeneralTab(generalGroup);
-
-        toggleEnableControls(moveEnabledCheckbox, destDirText, destDirButton, seasonPrefixText);
-        moveEnabledCheckbox.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                toggleEnableControls(moveEnabledCheckbox, destDirText,
-                                     destDirButton, seasonPrefixText);
-            }
-        });
 
         item.setControl(generalGroup);
     }

--- a/src/test/org/tvrenamer/model/FileEpisodeTest.java
+++ b/src/test/org/tvrenamer/model/FileEpisodeTest.java
@@ -1083,8 +1083,8 @@ public class FileEpisodeTest {
      */
     @Test
     public void testGetReplacementText() {
-        prefs.setMoveEnabled(false);
         prefs.setRenameEnabled(true);
+        prefs.setMoveEnabled(false);
         List<Path> testFiles = new ArrayList<>();
         for (EpisodeTestData data : values) {
             try {


### PR DESCRIPTION
Make sure that if move is disabled, that rename is enabled.

In the preferences dialog, if move is disabled, do not allow the user to disable rename.  If rename is disabled, do not allow the user to disable move.

With the change to the preferences dialog in place, the user would not be able to turn both options off.  But, it is theoretically possible that they turned them both off in a previous release of TVRenamer, and saved them out that way, and then we would load them back in that way.  So, do a check when we load UserPreferences, and if they're both disabled, enable rename, and store the prefs.

By the same token, add code to setMoveEnabled and setRenameEnabled to prevent them from both being disabled, even though there should be no way to reach that code in the application.  Just in case.