### PR TITLE
Issue #68, Delete emptied directories when 'Move to TV Directory'

### DIFF
--- a/src/main/org/tvrenamer/model/UserPreferences.java
+++ b/src/main/org/tvrenamer/model/UserPreferences.java
@@ -45,7 +45,7 @@ public class UserPreferences extends Observable {
         seasonPrefixLeadingZero = false;
         moveEnabled = false;
         renameEnabled = true;
-        removeEmptiedDirectories = false;
+        removeEmptiedDirectories = true;
         renameReplacementMask = DEFAULT_REPLACEMENT_MASK;
         checkForUpdates = true;
         recursivelyAddFolders = true;

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -94,6 +94,9 @@ public class Constants {
     public static final String RECURSE_FOLDERS_TEXT = "Recursively add shows in subdirectories [?]";
     public static final String RECURSE_FOLDERS_TOOLTIP = "If unchecked, do not look into subfolders "
         + "for shows to add";
+    public static final String REMOVE_EMPTIED_TEXT = "Remove emptied directories [?]";
+    public static final String REMOVE_EMPTIED_TOOLTIP = "When selected, directories which become empty "
+        + "due to file movement will be deleted.";
     public static final String CHECK_UPDATES_TEXT = "Check for Updates at startup [?]";
     public static final String CHECK_UPDATES_TOOLTIP = "If checked, will automatically check "
         + APPLICATION_NAME + " website for new versions at startup, and offer to update if found";

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -129,6 +129,7 @@ class PreferencesDialog extends Dialog {
     private Text ignoreWordsText;
     private Button checkForUpdatesCheckbox;
     private Button recurseFoldersCheckbox;
+    private Button rmdirEmptyCheckbox;
     private Shell preferencesShell;
 
     /**
@@ -307,6 +308,9 @@ class PreferencesDialog extends Dialog {
         recurseFoldersCheckbox = createCheckbox(RECURSE_FOLDERS_TEXT, RECURSE_FOLDERS_TOOLTIP,
                                                 prefs.isRecursivelyAddFolders(), generalGroup,
                                                 GridData.BEGINNING, 3);
+        rmdirEmptyCheckbox = createCheckbox(REMOVE_EMPTIED_TEXT, REMOVE_EMPTIED_TOOLTIP,
+                                            prefs.isRemoveEmptiedDirectories(), generalGroup,
+                                            GridData.BEGINNING, 3);
         checkForUpdatesCheckbox = createCheckbox(CHECK_UPDATES_TEXT, CHECK_UPDATES_TOOLTIP,
                                                  prefs.checkForUpdates(), generalGroup,
                                                  GridData.BEGINNING, 3);
@@ -453,6 +457,7 @@ class PreferencesDialog extends Dialog {
         prefs.setIgnoreKeywords(ignoreWordsText.getText());
         prefs.setCheckForUpdates(checkForUpdatesCheckbox.getSelection());
         prefs.setRecursivelyAddFolders(recurseFoldersCheckbox.getSelection());
+        prefs.setRemoveEmptiedDirectories(rmdirEmptyCheckbox.getSelection());
         prefs.setDestinationDirectory(destDirText.getText());
 
         boolean isRenameEnabled = renameEnabledCheckbox.getSelection();


### PR DESCRIPTION
The functionality actually has been present since last May.  Finally added the UI.  :-)  Simply a checkbox, on a separate line, between "Recursively add shows" and "Check for Updates".

Now that there's a UI to control it, make the default be to delete emptied directories.  Users can change the setting with the preferences dialog.

Note, this deletes emptIED directories, not necessarily empty ones.  If the user adds a folder, and the folder contains an empty subfolder, that subfolder will not be removed (regardless of setting).  This only checks directories for emptiness after a file has been moved out of it.