### PR TITLE
Reinstate app name

### DIFF
--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -33,10 +33,10 @@ public final class UIStarter {
 
     public UIStarter() {
         // Setup display and shell
+        Display.setAppName(APPLICATION_NAME);
         display = new Display();
         shell = new Shell(display);
 
-        Display.setAppName(APPLICATION_NAME);
         shell.setText(APPLICATION_NAME);
 
         GridLayout shellGridLayout = new GridLayout(3, false);


### PR DESCRIPTION
For some reason, setting the app name using the Display static method doesn't seem to work after I've instantiated a display.  So, restore the ordering to how it was.