### PR TITLE
A few changes from previous and future commits

### DIFF
--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -87,8 +87,8 @@ public class Constants {
     public static final String IGNORE_WORDS_SPLIT_REGEX = "\\s*,\\s*";
     public static final String GENERAL_LABEL = "General";
     public static final String RENAMING_LABEL = "Renaming";
-    public static final String MOVE_ENABLED_TEXT = "Move Enabled [?]";
-    public static final String RENAME_ENABLED_TEXT = "Rename Enabled [?]";
+    public static final String MOVE_SELECTED_TEXT = "Move Enabled [?]";
+    public static final String RENAME_SELECTED_TEXT = "Rename Enabled [?]";
     public static final String DEST_DIR_TEXT = "TV Directory [?]";
     public static final String DEST_DIR_BUTTON_TEXT = "Select directory";
     public static final String DIR_DIALOG_TEXT = "Please select a directory and click OK";
@@ -109,7 +109,7 @@ public class Constants {
         + "moved/renamed, delete the row from the table.";
     public static final String RENAME_TOKEN_TEXT = "Rename Tokens [?]";
     public static final String RENAME_FORMAT_TEXT = "Rename Format [?]";
-    public static final String RENAME_ENABLED_TOOLTIP = "Whether the 'rename' functionality is enabled.\n"
+    public static final String RENAME_SELECTED_TOOLTIP = "Whether the 'rename' functionality is enabled.\n"
         + "You can move a file into a folder based on its show\n"
         + "without actually renaming the file";
     public static final String HELP_TOOLTIP = "Hover mouse over [?] to get help";
@@ -117,7 +117,7 @@ public class Constants {
         + "to your 'TV' folder if you want it to.  \n"
         + " - It will move the file to <tv directory>/<series name>/<season prefix> #/ \n"
         + " - Once enabled, set the location below.";
-    public static final String MOVE_ENABLED_TOOLTIP = "Whether the "
+    public static final String MOVE_SELECTED_TOOLTIP = "Whether the "
         + "'move to TV location' functionality is enabled";
     public static final String DEST_DIR_TOOLTIP = "The location of your 'TV' folder";
     public static final String PREFIX_TOOLTIP = " - The prefix of the season when renaming and "

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -285,7 +285,7 @@ class PreferencesDialog extends Dialog {
                                                          prefs.isSeasonPrefixLeadingZero(),
                                                          generalGroup, GridData.BEGINNING, 3);
 
-        toggleEnableControls(moveEnabledCheckbox.getSelection(), destDirText, destDirButton,
+        toggleEnableControls(moveIsEnabled, destDirText, destDirButton,
                              seasonPrefixText, seasonPrefixLeadingZeroCheckbox);
 
         moveEnabledCheckbox.addSelectionListener(new SelectionAdapter() {

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -119,8 +119,8 @@ class PreferencesDialog extends Dialog {
     }
 
     // The controls to save
-    private Button moveEnabledCheckbox;
-    private Button renameEnabledCheckbox;
+    private Button moveSelectedCheckbox;
+    private Button renameSelectedCheckbox;
     private Text destDirText;
     private Button destDirButton;
     private Text seasonPrefixText;
@@ -251,12 +251,12 @@ class PreferencesDialog extends Dialog {
     }
 
     private void populateGeneralTab(final Composite generalGroup) {
-        final boolean moveIsEnabled = prefs.isMoveEnabled();
-        boolean renameIsEnabled = prefs.isRenameEnabled();
-        moveEnabledCheckbox = createCheckbox(MOVE_ENABLED_TEXT, MOVE_ENABLED_TOOLTIP,
-                                             moveIsEnabled, generalGroup, GridData.BEGINNING, 2);
-        renameEnabledCheckbox = createCheckbox(RENAME_ENABLED_TEXT, RENAME_ENABLED_TOOLTIP,
-                                               renameIsEnabled, generalGroup, GridData.END, 1);
+        final boolean moveIsSelected = prefs.isMoveEnabled();
+        boolean renameIsSelected = prefs.isRenameEnabled();
+        moveSelectedCheckbox = createCheckbox(MOVE_SELECTED_TEXT, MOVE_SELECTED_TOOLTIP,
+                                              moveIsSelected, generalGroup, GridData.BEGINNING, 2);
+        renameSelectedCheckbox = createCheckbox(RENAME_SELECTED_TEXT, RENAME_SELECTED_TOOLTIP,
+                                                renameIsSelected, generalGroup, GridData.END, 1);
 
         createLabel(DEST_DIR_TEXT, DEST_DIR_TOOLTIP, generalGroup);
         destDirText = createText(prefs.getDestinationDirectoryName(), generalGroup, false);
@@ -285,13 +285,13 @@ class PreferencesDialog extends Dialog {
                                                          prefs.isSeasonPrefixLeadingZero(),
                                                          generalGroup, GridData.BEGINNING, 3);
 
-        toggleEnableControls(moveIsEnabled, destDirText, destDirButton,
+        toggleEnableControls(moveIsSelected, destDirText, destDirButton,
                              seasonPrefixText, seasonPrefixLeadingZeroCheckbox);
 
-        moveEnabledCheckbox.addSelectionListener(new SelectionAdapter() {
+        moveSelectedCheckbox.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                toggleEnableControls(moveEnabledCheckbox.getSelection(), destDirText, destDirButton,
+                toggleEnableControls(moveSelectedCheckbox.getSelection(), destDirText, destDirButton,
                                      seasonPrefixText, seasonPrefixLeadingZeroCheckbox);
             }
         });
@@ -427,12 +427,12 @@ class PreferencesDialog extends Dialog {
      */
     private void savePreferences() {
         // Update the preferences object from the UI control values
-        prefs.setMoveEnabled(moveEnabledCheckbox.getSelection());
+        prefs.setMoveEnabled(moveSelectedCheckbox.getSelection());
         prefs.setSeasonPrefix(seasonPrefixString);
         prefs.setSeasonPrefixLeadingZero(seasonPrefixLeadingZeroCheckbox.getSelection());
         prefs.setRenameReplacementString(replacementStringText.getText());
         prefs.setIgnoreKeywords(ignoreWordsText.getText());
-        prefs.setRenameEnabled(renameEnabledCheckbox.getSelection());
+        prefs.setRenameEnabled(renameSelectedCheckbox.getSelection());
 
         prefs.setCheckForUpdates(checkForUpdatesCheckbox.getSelection());
         prefs.setRecursivelyAddFolders(recurseFoldersCheckbox.getSelection());

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -526,20 +526,24 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         item.setChecked(false);
     }
 
+    private void setTableItemStatus(final TableItem item, final int epsFound) {
+        if (epsFound > 1) {
+            setCellImage(item, STATUS_COLUMN, OPTIONS);
+            item.setChecked(true);
+        } else if (epsFound == 1) {
+            setCellImage(item, STATUS_COLUMN, SUCCESS);
+            item.setChecked(true);
+        } else {
+            failTableItem(item);
+        }
+    }
+
     private void listingsDownloaded(final TableItem item, final FileEpisode episode) {
         int epsFound = episode.listingsComplete();
         display.asyncExec(() -> {
             if (tableContainsTableItem(item)) {
                 setProposedDestColumn(item, episode);
-                if (epsFound > 1) {
-                    setCellImage(item, STATUS_COLUMN, OPTIONS);
-                    item.setChecked(true);
-                } else if (epsFound == 1) {
-                    setCellImage(item, STATUS_COLUMN, SUCCESS);
-                    item.setChecked(true);
-                } else {
-                    failTableItem(item);
-                }
+                setTableItemStatus(item, epsFound);
             }
         });
     }
@@ -828,6 +832,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             episodeMap.put(newFileName, episode);
             setCellText(item, CURRENT_FILE_COLUMN, newFileName);
             setProposedDestColumn(item, episode);
+            setTableItemStatus(item, episode.optionCount());
         }
     }
 


### PR DESCRIPTION
"Refresh table item status when refreshing table" - this should have been done when adding the OPTIONS status

"Use an instance variable and a ModifyListener to keep track of season…" - slightly reworks what we did in "Rework season prefix"

"Simplify call to toggleEnableControls" - should have been part of "Rework toggleEnableControls"

"Change 'enabled' to 'selected' regarding whether we move or rename files" - part of the eventual solution to #164 