### PR TITLE
Add verifier for season prefix text

### DIFF
--- a/src/main/org/tvrenamer/controller/util/StringUtils.java
+++ b/src/main/org/tvrenamer/controller/util/StringUtils.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.text.DecimalFormat;
 import java.util.HashMap;
 import java.util.Locale;
+import java.util.Set;
 import java.util.logging.Logger;
 
 public class StringUtils {
@@ -32,7 +33,7 @@ public class StringUtils {
                 put('`', "'");  // replace backquote with apostrophe
             }
         };
-
+    public static final Set<Character> ILLEGAL_CHARACTERS = SANITISE.keySet();
 
     private static final ThreadLocal<DecimalFormat> DIGITS =
         new ThreadLocal<DecimalFormat>() {
@@ -144,6 +145,16 @@ public class StringUtils {
         }
 
         return original.substring(start, end);
+    }
+
+    /**
+     * Return whether or not the given character is legal in filenames.
+     *
+     * @param ch the character to check
+     * @return true if the character is ok to include in filenames, false if it is not
+     */
+    public static boolean isLegalFilenameCharacter(final char ch) {
+        return !ILLEGAL_CHARACTERS.contains(ch);
     }
 
     /**

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -164,6 +164,10 @@ public class Constants {
         + "used in file paths:";
     public static final String ILLEGAL_CHARACTERS_WARNING = ILLEGAL_CHARS_INTRO
         + charsToSpaceString(StringUtils.ILLEGAL_CHARACTERS);
+    public static final String NO_TEXT_BEFORE_OPENING_QUOTE = "Cannot insert text before "
+        + "the opening double quote";
+    public static final String NO_TEXT_AFTER_CLOSING_QUOTE = "Cannot insert text after "
+        + "the closing double quote";
 
     public static final String UPDATE_TEXT = "Check for Updates...";
     private static final String TO_DOWNLOAD = "Please visit " + TVRENAMER_PROJECT_URL

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -1,8 +1,11 @@
 package org.tvrenamer.model.util;
 
+import org.tvrenamer.controller.util.StringUtils;
+
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Set;
 
 /**
  * Constants.java -- the most important reason for this class to exist is for pieces of
@@ -66,6 +69,15 @@ public class Constants {
     public static final String SUBLINK_PATH = "/icons/SweetieLegacy/";
     public static final String LOGGING_PROPERTIES = "/logging.properties";
     public static final String DEVELOPER_DEFAULT_OVERRIDES_FILENAME = "etc/default-overrides.xml";
+
+    private static String charsToSpaceString(final Set<Character> chars) {
+        StringBuilder str = new StringBuilder(2 * chars.size());
+        for (Character c : chars) {
+            str.append(' ');
+            str.append(c);
+        }
+        return str.toString();
+    }
 
     public static final String QUIT_LABEL = "Quit";
     public static final String CANCEL_LABEL = "Cancel";
@@ -148,6 +160,10 @@ public class Constants {
         + "to take some action.";
     public static final String UNKNOWN_EXCEPTION = "An error occurred, please check "
         + "the console output to see any errors:";
+    public static final String ILLEGAL_CHARS_INTRO = "The following characters cannot be "
+        + "used in file paths:";
+    public static final String ILLEGAL_CHARACTERS_WARNING = ILLEGAL_CHARS_INTRO
+        + charsToSpaceString(StringUtils.ILLEGAL_CHARACTERS);
 
     public static final String UPDATE_TEXT = "Check for Updates...";
     private static final String TO_DOWNLOAD = "Please visit " + TVRENAMER_PROJECT_URL

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -255,18 +255,11 @@ class PreferencesDialog extends Dialog {
         return button;
     }
 
-    private void populateGeneralTab(final Composite generalGroup) {
-        final boolean moveIsSelected = prefs.isMoveEnabled();
-        boolean renameIsSelected = prefs.isRenameEnabled();
-        moveSelectedCheckbox = createCheckbox(MOVE_SELECTED_TEXT, MOVE_SELECTED_TOOLTIP,
-                                              moveIsSelected, generalGroup, GridData.BEGINNING, 2);
-        renameSelectedCheckbox = createCheckbox(RENAME_SELECTED_TEXT, RENAME_SELECTED_TOOLTIP,
-                                                renameIsSelected, generalGroup, GridData.END, 1);
-
-        createLabel(DEST_DIR_TEXT, DEST_DIR_TOOLTIP, generalGroup);
-        destDirText = createText(prefs.getDestinationDirectoryName(), generalGroup, false);
-        destDirButton = createDestDirButton(generalGroup);
-
+    /*
+     * Create the controls that regard the naming of the season prefix folder.
+     * The text box gets both a verify listener and a modify listener.
+     */
+    private void createSeasonPrefixControls(final Composite generalGroup) {
         createLabel(SEASON_PREFIX_TEXT, PREFIX_TOOLTIP, generalGroup);
         seasonPrefixString = prefs.getSeasonPrefix();
         seasonPrefixText = createText(StringUtils.makeQuotedString(seasonPrefixString),
@@ -289,6 +282,21 @@ class PreferencesDialog extends Dialog {
         seasonPrefixLeadingZeroCheckbox = createCheckbox(SEASON_PREFIX_ZERO_TEXT, SEASON_PREFIX_ZERO_TOOLTIP,
                                                          prefs.isSeasonPrefixLeadingZero(),
                                                          generalGroup, GridData.BEGINNING, 3);
+    }
+
+    private void populateGeneralTab(final Composite generalGroup) {
+        final boolean moveIsSelected = prefs.isMoveEnabled();
+        boolean renameIsSelected = prefs.isRenameEnabled();
+        moveSelectedCheckbox = createCheckbox(MOVE_SELECTED_TEXT, MOVE_SELECTED_TOOLTIP,
+                                              moveIsSelected, generalGroup, GridData.BEGINNING, 2);
+        renameSelectedCheckbox = createCheckbox(RENAME_SELECTED_TEXT, RENAME_SELECTED_TOOLTIP,
+                                                renameIsSelected, generalGroup, GridData.END, 1);
+
+        createLabel(DEST_DIR_TEXT, DEST_DIR_TOOLTIP, generalGroup);
+        destDirText = createText(prefs.getDestinationDirectoryName(), generalGroup, false);
+        destDirButton = createDestDirButton(generalGroup);
+
+        createSeasonPrefixControls(generalGroup);
 
         toggleEnableControls(moveIsSelected, destDirText, destDirButton,
                              seasonPrefixText, seasonPrefixLeadingZeroCheckbox);

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -35,10 +35,12 @@ import org.tvrenamer.controller.util.StringUtils;
 import org.tvrenamer.model.ReplacementToken;
 import org.tvrenamer.model.UserPreferences;
 
+import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 class PreferencesDialog extends Dialog {
+    private static final Logger logger = Logger.getLogger(PreferencesDialog.class.getName());
     private static final UserPreferences prefs = UserPreferences.getInstance();
 
     private static final int DND_OPERATIONS = DND.DROP_MOVE;

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -133,6 +133,8 @@ class PreferencesDialog extends Dialog {
     private Button deleteRowsCheckbox;
     private Shell preferencesShell;
 
+    private final StatusLabel statusLabel;
+
     private String seasonPrefixString;
 
     /**
@@ -143,6 +145,7 @@ class PreferencesDialog extends Dialog {
      */
     public PreferencesDialog(Shell parent) {
         super(parent, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
+        statusLabel = new StatusLabel();
     }
 
     public void open() {
@@ -164,7 +167,7 @@ class PreferencesDialog extends Dialog {
     }
 
     private void createContents() {
-        GridLayout shellGridLayout = new GridLayout(3, false);
+        GridLayout shellGridLayout = new GridLayout(4, false);
         preferencesShell.setLayout(shellGridLayout);
 
         Label helpLabel = new Label(preferencesShell, SWT.NONE);
@@ -178,6 +181,8 @@ class PreferencesDialog extends Dialog {
 
         createGeneralTab(tabFolder);
         createRenameTab(tabFolder);
+
+        statusLabel.open(preferencesShell, shellGridLayout.numColumns);
 
         createActionButtonGroup();
     }

--- a/src/main/org/tvrenamer/view/StatusLabel.java
+++ b/src/main/org/tvrenamer/view/StatusLabel.java
@@ -1,0 +1,79 @@
+package org.tvrenamer.view;
+
+import static org.tvrenamer.model.util.Constants.*;
+
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridData;
+import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Shell;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.logging.Logger;
+
+public class StatusLabel {
+    private static final Logger logger = Logger.getLogger(StatusLabel.class.getName());
+
+    private final Deque<String> statusStack = new ArrayDeque<>();
+
+    private Shell parentShell;
+    private Label statusLabel;
+    private boolean started = false;
+
+    private void refreshStatusLabel() {
+        if (statusStack.isEmpty()) {
+            statusLabel.setText(EMPTY_STRING);
+        } else {
+            statusLabel.setText(statusStack.peekFirst());
+        }
+        parentShell.layout();
+    }
+
+    public void add(final String statusText) {
+        if (statusText == null) {
+            logger.info("cannot set null status");
+            return;
+        }
+        statusStack.remove(statusText);
+        statusStack.addFirst(statusText);
+        if (!started) {
+            // could potentially happen during startup?
+            return;
+        }
+        refreshStatusLabel();
+    }
+
+    public void clear(final String statusText) {
+        if (statusText == null) {
+            // not used and not recommended; but provided, just in case
+            statusStack.clear();
+        } else {
+            boolean found = statusStack.remove(statusText);
+            if (!found) {
+                logger.fine("did not find \"" + statusText + "\" in status stack");
+            }
+        }
+        if (!started) {
+            // could potentially happen during startup?
+            return;
+        }
+        refreshStatusLabel();
+    }
+
+    /**
+     * Start status label
+     *
+     * @param parent
+     *            the parent {@link Shell}
+     * @param numColumns
+     *            how many columns the label should span
+     */
+    public void open(final Shell parent, final int numColumns) {
+        parentShell = parent;
+        statusLabel = new Label(parentShell, SWT.NONE);
+        statusLabel.setLayoutData(new GridData(SWT.CENTER, SWT.TOP, true, true,
+                                               numColumns, 1));
+        started = true;
+        refreshStatusLabel();
+    }
+}


### PR DESCRIPTION
There are certain characters we cannot allow in the "season prefix" text, because it is used to create a directory, and there are some characters that are not permitted in filenames.

What we were doing was, allow the user to type whatever, and then (silently) filtering it when they were done.

I saw that SWT allows a "verifier", and decided to try that instead.

Ultimately, it works pretty well, but it was quite involved for such a tiny feature.  Was probably not worth the effort.  But, it's done now.

I commented the new code extensively.  Please see the VerifyListener for "seasonPrefixText", and associated methods, for details on what I did.

As part of this work, I created a new class, StatusLabel, and used it to add a status bar to the preferences dialog.  I may expand the StatusLabel class more going forward.