### PR TITLE
make table refreshes more efficient, more

### DIFF
--- a/src/main/org/tvrenamer/controller/AddEpisodeListener.java
+++ b/src/main/org/tvrenamer/controller/AddEpisodeListener.java
@@ -7,5 +7,5 @@ import java.util.Queue;
 public interface AddEpisodeListener {
     void addEpisodes(Queue<FileEpisode> episodes);
 
-    void refreshAll();
+    void refreshDestinations();
 }

--- a/src/main/org/tvrenamer/controller/FileMover.java
+++ b/src/main/org/tvrenamer/controller/FileMover.java
@@ -118,8 +118,8 @@ public class FileMover implements Callable<Boolean> {
                 fos.write(buffer, 0, n);
                 copied += n;
                 if (observer != null) {
-                    observer.setStatus(StringUtils.formatFileSize(copied));
-                    observer.setValue(copied);
+                    observer.setProgressStatus(StringUtils.formatFileSize(copied));
+                    observer.setProgressValue(copied);
                 }
                 if (Thread.interrupted()) {
                     break;
@@ -179,7 +179,7 @@ public class FileMover implements Callable<Boolean> {
         } else {
             logger.info("different disks: " + srcPath + " and " + destPath);
             if (observer != null) {
-                observer.initialize(episode.getFileSize());
+                observer.initializeProgress(episode.getFileSize());
             }
             boolean success = copyAndDelete(srcPath, destPath);
             if (observer != null) {

--- a/src/main/org/tvrenamer/controller/util/FileUtilities.java
+++ b/src/main/org/tvrenamer/controller/util/FileUtilities.java
@@ -85,20 +85,24 @@ public class FileUtilities {
     }
 
     /**
-     * Return true if the given arguments refer to the same actual file on the
-     * file system.  On file systems that support symbolic links, two Paths could
+     * Return true if the given arguments refer to the same actual, existing file on
+     * the file system.  On file systems that support symbolic links, two Paths could
      * be the same file even if their locations appear completely different.
      *
      * @param path1
-     *    first Path to compare
+     *    first Path to compare; it is expected that this Path exists
      * @param path2
-     *    second Path to compare
+     *    second Path to compare; this may or may not exist
      * @return
-     *    true if the paths refer to the same file, false if they don't
+     *    true if the paths refer to the same file, false if they don't;
+     *    logs an exception if one occurs while trying to check, including
+     *    if path1 does not exist; but does not log one if path2 doesn't
      */
-    @SuppressWarnings("SameParameterValue")
     public static boolean isSameFile(final Path path1, final Path path2) {
         try {
+            if (Files.notExists(path2)) {
+                return false;
+            }
             return Files.isSameFile(path1, path2);
         } catch (IOException ioe) {
             logger.log(Level.WARNING, "exception checking files "

--- a/src/main/org/tvrenamer/model/EpisodeDb.java
+++ b/src/main/org/tvrenamer/model/EpisodeDb.java
@@ -300,7 +300,7 @@ public class EpisodeDb implements Observer {
                     ep.setIgnoreReason(ignorableReason(ep.getFilepath()));
                 }
                 for (AddEpisodeListener listener : listeners) {
-                    listener.refreshAll();
+                    listener.refreshDestinations();
                 }
             }
         }

--- a/src/main/org/tvrenamer/model/EpisodeDb.java
+++ b/src/main/org/tvrenamer/model/EpisodeDb.java
@@ -1,6 +1,7 @@
 package org.tvrenamer.model;
 
 import org.tvrenamer.controller.AddEpisodeListener;
+import org.tvrenamer.controller.util.FileUtilities;
 
 import java.io.IOException;
 import java.nio.file.DirectoryStream;
@@ -93,6 +94,66 @@ public class EpisodeDb implements Observer {
             logger.finer("could not access file; treating as hidden: " + path);
         }
         return isVisible;
+    }
+
+    /**
+     * Get the current location -- and, therefore, the database key -- for the
+     * file that has been referred to by the given key.
+     *
+     * That is, we know where the file USED TO be.  It may still be there; it may
+     * have moved.  Tell the caller where it is now, which is also how to retrieve
+     * its FileEpisode object.
+     * 
+     * @param key
+     *     a String, representing a path to the last known location of the file,
+     *     to look up and check
+     * @return the current location, if the file still exists; null if the file
+     *     is no longer valid
+     *
+     * The method might change the internal database, if it detects the file has
+     * been moved.  That means, the key given will no longer be valid when the
+     * method returns.  The return value does not explicitly give an indication
+     * of whether or not that's true.  Callers must simply use the returned value
+     * as the key after this function returns, or must do a comparison with the
+     * previous key to see if it's still valid.
+     *     
+     */
+    public String currentLocationOf(final String key) {
+        if (key == null) {
+            return null;
+        }
+        FileEpisode ep = episodes.get(key);
+        if (ep == null) {
+            return null;
+        }
+        Path currentLocation = ep.getPath();
+        if (fileIsVisible(currentLocation) && Files.isRegularFile(currentLocation)) {
+            // OK, the file is good!  But that could be true even if
+            // it were moved.  Now try to see if it's been moved, or if
+            // it's still where we think it is.
+            String direct = currentLocation.toString();
+            if (key.equals(direct)) {
+                return key;
+            }
+            // Even if the strings don't match directly, we're not going
+            // to change anything if they both refer to the same file.
+            // Though, maybe we should?  TODO
+            Path keyPath = Paths.get(key);
+            if (FileUtilities.isSameFile(currentLocation, keyPath)) {
+                return key;
+            }
+            // The file has been moved.  We update our database, and inform the
+            // caller of the new key.
+            episodes.remove(key);
+            episodes.put(direct, ep);
+            return direct;
+        } else {
+            // The file has disappeared out from under us (or, bizarrely, been replaced
+            // by a directory?  Anything is possible...).  Remove it from the db and let
+            // the caller know by returning null.
+            episodes.remove(key);
+            return null;
+        }
     }
 
     private void addFileToQueue(final Queue<FileEpisode> contents,

--- a/src/main/org/tvrenamer/model/ProgressObserver.java
+++ b/src/main/org/tvrenamer/model/ProgressObserver.java
@@ -1,7 +1,7 @@
 /*
  * ProgressObserver.java - Progression monitor
  *
- * Based on org.gjt.sp.util.ProgressObserver, though we add a cleanUp method
+ * Based on org.gjt.sp.util.ProgressObserver, though we add a finish method
  */
 
 package org.tvrenamer.model;
@@ -11,7 +11,7 @@ package org.tvrenamer.model;
  *
  * It should not be assumed that a ProgressObserver is ready to go upon construction,
  * or that it will clean up after itself once you stop using it.  It is required to
- * call initialize() before anything else, and cleanUp() when you're done.
+ * call initializeProgress() before anything else, and finishProgress() when you're done.
  */
 public interface ProgressObserver {
     /**
@@ -20,21 +20,21 @@ public interface ProgressObserver {
      * @param max
      *    the new maximum value
      */
-    void initialize(long max);
+    void initializeProgress(long max);
 
     /**
      * Update the progress value.
      *
      * @param value the new value
      */
-    void setValue(long value);
+    void setProgressValue(long value);
 
     /**
      * Update the status label.
      *
      * @param status the new status label
      */
-    void setStatus(String status);
+    void setProgressStatus(String status);
 
     /**
      * Finish the activity

--- a/src/main/org/tvrenamer/view/FileCopyMonitor.java
+++ b/src/main/org/tvrenamer/view/FileCopyMonitor.java
@@ -32,15 +32,15 @@ public class FileCopyMonitor implements ProgressObserver {
     }
 
     /**
-     * Update the maximum value.
+     * Set the maximum value.
      *
      * @param max the new maximum value
      */
     @Override
-    public void initialize(final long max) {
+    public void initializeProgress(final long max) {
         display.syncExec(() -> label = ui.getProgressLabel(item));
         maximum = max;
-        setValue(0);
+        setProgressValue(0);
     }
 
     /**
@@ -49,7 +49,7 @@ public class FileCopyMonitor implements ProgressObserver {
      * @param value the new value
      */
     @Override
-    public void setValue(final long value) {
+    public void setProgressValue(final long value) {
         if (loopCount++ % 500 == 0) {
             display.asyncExec(() -> {
                 if (label.isDisposed()) {
@@ -66,7 +66,7 @@ public class FileCopyMonitor implements ProgressObserver {
      * @param status the new status label
      */
     @Override
-    public void setStatus(final String status) {
+    public void setProgressStatus(final String status) {
         display.asyncExec(() -> {
             if (label.isDisposed()) {
                 return;

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -136,30 +136,13 @@ class PreferencesDialog extends Dialog {
     private Button recurseFoldersCheckbox;
     private Button rmdirEmptyCheckbox;
     private Button deleteRowsCheckbox;
+    private TabFolder tabFolder;
     private Shell preferencesShell;
 
     private final Shell parent;
     private final StatusLabel statusLabel;
 
     private String seasonPrefixString;
-
-    public void open() {
-        // Create the dialog window
-        preferencesShell = new Shell(parent, getStyle());
-        preferencesShell.setText(PREFERENCES_LABEL);
-
-        // Add the contents of the dialog window
-        createContents();
-
-        preferencesShell.pack();
-        preferencesShell.open();
-        Display display = parent.getDisplay();
-        while (!preferencesShell.isDisposed()) {
-            if (!display.readAndDispatch()) {
-                display.sleep();
-            }
-        }
-    }
 
     private void createContents() {
         GridLayout shellGridLayout = new GridLayout(4, false);
@@ -170,12 +153,12 @@ class PreferencesDialog extends Dialog {
         helpLabel.setLayoutData(new GridData(SWT.END, SWT.CENTER, true, true,
                                              shellGridLayout.numColumns, 1));
 
-        TabFolder tabFolder = new TabFolder(preferencesShell, getStyle());
+        tabFolder = new TabFolder(preferencesShell, getStyle());
         tabFolder.setLayoutData(new GridData(SWT.END, SWT.CENTER, true, true,
                                              shellGridLayout.numColumns, 1));
 
-        createGeneralTab(tabFolder);
-        createRenameTab(tabFolder);
+        createGeneralTab();
+        createRenameTab();
 
         statusLabel.open(preferencesShell, shellGridLayout.numColumns);
 
@@ -467,7 +450,7 @@ class PreferencesDialog extends Dialog {
         renameSelectedCheckbox.setSelection(renameIsSelected);
     }
 
-    private void createGeneralTab(final TabFolder tabFolder) {
+    private void createGeneralTab() {
         final TabItem item = new TabItem(tabFolder, SWT.NULL);
         item.setText(GENERAL_LABEL);
 
@@ -482,7 +465,7 @@ class PreferencesDialog extends Dialog {
         item.setControl(generalGroup);
     }
 
-    private void createRenameTab(TabFolder tabFolder) {
+    private void createRenameTab() {
         TabItem item = new TabItem(tabFolder, SWT.NULL);
         item.setText(RENAMING_LABEL);
 
@@ -597,6 +580,28 @@ class PreferencesDialog extends Dialog {
         prefs.setRenameSelected(renameSelectedCheckbox.getSelection());
 
         UserPreferences.store(prefs);
+    }
+
+    /**
+     * Creates and opens the preferences dialog, and runs the event loop.
+     *
+     */
+    public void open() {
+        // Create the dialog window
+        preferencesShell = new Shell(parent, getStyle());
+        preferencesShell.setText(PREFERENCES_LABEL);
+
+        // Add the contents of the dialog window
+        createContents();
+
+        preferencesShell.pack();
+        preferencesShell.open();
+        Display display = parent.getDisplay();
+        while (!preferencesShell.isDisposed()) {
+            if (!display.readAndDispatch()) {
+                display.sleep();
+            }
+        }
     }
 
     /**

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -138,24 +138,14 @@ class PreferencesDialog extends Dialog {
     private Button deleteRowsCheckbox;
     private Shell preferencesShell;
 
+    private final Shell parent;
     private final StatusLabel statusLabel;
 
     private String seasonPrefixString;
 
-    /**
-     * PreferencesDialog constructor
-     *
-     * @param parent
-     *            the parent {@link Shell}
-     */
-    public PreferencesDialog(Shell parent) {
-        super(parent, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
-        statusLabel = new StatusLabel();
-    }
-
     public void open() {
         // Create the dialog window
-        preferencesShell = new Shell(getParent(), getStyle());
+        preferencesShell = new Shell(parent, getStyle());
         preferencesShell.setText(PREFERENCES_LABEL);
 
         // Add the contents of the dialog window
@@ -163,7 +153,7 @@ class PreferencesDialog extends Dialog {
 
         preferencesShell.pack();
         preferencesShell.open();
-        Display display = getParent().getDisplay();
+        Display display = parent.getDisplay();
         while (!preferencesShell.isDisposed()) {
             if (!display.readAndDispatch()) {
                 display.sleep();
@@ -607,5 +597,17 @@ class PreferencesDialog extends Dialog {
         prefs.setRenameSelected(renameSelectedCheckbox.getSelection());
 
         UserPreferences.store(prefs);
+    }
+
+    /**
+     * PreferencesDialog constructor
+     *
+     * @param parent
+     *            the parent {@link Shell}
+     */
+    public PreferencesDialog(final Shell parent) {
+        super(parent, SWT.DIALOG_TRIM | SWT.APPLICATION_MODAL);
+        this.parent = parent;
+        statusLabel = new StatusLabel();
     }
 }

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -142,6 +142,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                                      final int columnId,
                                      final Image newImage)
     {
+        if (item.isDisposed()) {
+            return;
+        }
         item.setImage(columnId, newImage);
     }
 
@@ -149,7 +152,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                                      final int columnId,
                                      final FileMoveIcon.Status newStatus)
     {
-        item.setImage(columnId, FileMoveIcon.getIcon(newStatus));
+        setCellImage(item, columnId, FileMoveIcon.getIcon(newStatus));
     }
 
     private static String getCellText(final TableItem item, final int columnId) {
@@ -160,6 +163,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                                     final int columnId,
                                     final String newText)
     {
+        if (item.isDisposed()) {
+            return;
+        }
         item.setText(columnId, newText);
     }
 
@@ -172,6 +178,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     }
 
     private void setComboBoxProposedDest(final TableItem item, final FileEpisode ep) {
+        if (swtTable.isDisposed() || item.isDisposed()) {
+            return;
+        }
         final List<String> options = ep.getReplacementOptions();
         final int chosen = ep.getChosenEpisode();
         final String defaultOption = options.get(chosen);
@@ -210,6 +219,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
      *    the FileEpisode to use to obtain the text
      */
     private void setProposedDestColumn(final TableItem item, final FileEpisode ep) {
+        if (swtTable.isDisposed() || item.isDisposed()) {
+            return;
+        }
         deleteItemCombo(item);
 
         int nOptions = ep.optionCount();

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -541,15 +541,19 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         sortTable(column, columnNum, sortDirection);
     }
 
-    public void refreshAll() {
-        logger.info("Refreshing table");
+    public void refreshDestinations() {
+        logger.info("Refreshing destinations");
         for (TableItem item : swtTable.getItems()) {
             String fileName = getCellText(item, CURRENT_FILE_FIELD);
-            FileEpisode episode = episodeMap.remove(fileName);
+            String newFileName = episodeMap.currentLocationOf(fileName);
+            if (newFileName == null) {
+                // Not expected, but could happen, primarily if some other,
+                // unrelated program moves the file out from under us.
+                deleteTableItem(item);
+                return;
+            }
+            FileEpisode episode = episodeMap.get(newFileName);
             episode.refreshReplacement();
-            String newFileName = episode.getFilepath();
-            episodeMap.put(newFileName, episode);
-            setCellText(item, CURRENT_FILE_FIELD, newFileName);
             setProposedDestColumn(item, episode);
             setTableItemStatus(item, episode.optionCount());
         }
@@ -640,7 +644,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             case REPLACEMENT_MASK:
             case SEASON_PREFIX:
             case LEADING_ZERO:
-                refreshAll();
+                refreshDestinations();
             // Also note, no default case.  We know there are other types of
             // UserPreference events that we might be notified of.  We're
             // just not interested.

--- a/src/main/org/tvrenamer/view/UIStarter.java
+++ b/src/main/org/tvrenamer/view/UIStarter.java
@@ -84,8 +84,8 @@ public final class UIStarter {
     public void showMessageBox(final SWTMessageBoxType type, final String title,
                                final String message, final Exception exception)
     {
-        if (shell == null) {
-            // Shell not established yet, try using JOptionPane instead
+        if ((shell == null) || shell.isDisposed()) {
+            // Shell not established, try using JOptionPane instead
             try {
                 JOptionPane.showMessageDialog(null, message);
                 return;


### PR DESCRIPTION
We had a method, refreshAll, which did just that and was used in a few different places.  Change it to try to avoid any unnecessary work.  Some other small changes.  Please see individual commits for details.