### PR TITLE
Add Column, Field, and Fields classes

### DIFF
--- a/etc/checks.xml
+++ b/etc/checks.xml
@@ -11,6 +11,9 @@
             <property name="eachLine" value="true"/>
         </module>
 
+    <module name="SuppressionFilter">
+        <property name="file" value="etc/nochecks.xml"/>
+    </module>
     <module name="SuppressionCommentFilter">
         <property name="offCommentFormat" value="BEGIN IGNORE STYLE"/>
         <property name="onCommentFormat" value="END IGNORE STYLE"/>
@@ -20,6 +23,12 @@
         <property name="format" value="\s+$"/>
     </module>
     <module name="TreeWalker">
+        <module name="JavadocMethod">
+            <property name="scope" value="protected"/>
+            <property name="minLineCount" value="2"/>
+            <property name="allowMissingParamTags" value="false"/>
+            <property name="allowMissingReturnTag" value="false"/>
+        </module>
         <module name="SingleLineJavadoc">
             <property name="ignoreInlineTags" value="false"/>
         </module>

--- a/etc/nochecks.xml
+++ b/etc/nochecks.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<!DOCTYPE suppressions PUBLIC
+    "-//Puppy Crawl//DTD Suppressions 1.1//EN"
+    "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+
+<suppressions>
+    <suppress files="src/test/org/tvrenamer/controller/FilenameParserTest.java" checks="JavadocMethod"/>
+    <suppress files="src/test/org/tvrenamer/controller/TheTVDBProviderTest.java" checks="JavadocMethod"/>
+    <suppress files="src/test/org/tvrenamer/model/EpisodeTestData.java" checks="JavadocMethod"/>
+    <suppress files="src/test/org/tvrenamer/model/FileEpisodeTest.java" checks="JavadocMethod"/>
+    <suppress files="src/test/org/tvrenamer/controller/util/StringUtilsTest.java" checks="JavadocMethod"/>
+    <suppress files="src/test/org/tvrenamer/controller/util/FileUtilsTest.java" checks="JavadocMethod"/>
+
+    <suppress files="src/main/org/tvrenamer/model/GlobalOverrides.java" checks="JavadocMethod"/>
+    <suppress files="src/main/org/tvrenamer/controller/util/XPathUtilities.java" checks="JavadocMethod"/>
+</suppressions>

--- a/src/main/org/tvrenamer/model/util/Constants.java
+++ b/src/main/org/tvrenamer/model/util/Constants.java
@@ -89,7 +89,7 @@ public class Constants {
     public static final String RENAME_LABEL = "Rename Checked";
     public static final String JUST_MOVE_LABEL = "Move Checked";
     public static final String RENAME_AND_MOVE = "Rename && Move Checked";
-    public static final String CHECKBOX_HEADER = "Active";
+    public static final String CHECKBOX_HEADER = String.valueOf((char) 0x2705);
     public static final String SOURCE_HEADER = "Current File";
     public static final String MOVE_HEADER = "Proposed File Path";
     public static final String RENAME_HEADER = "Proposed File Name";

--- a/src/main/org/tvrenamer/view/CheckboxField.java
+++ b/src/main/org/tvrenamer/view/CheckboxField.java
@@ -1,0 +1,41 @@
+package org.tvrenamer.view;
+
+import org.eclipse.swt.widgets.TableItem;
+
+/**
+ * A field that is intended to hold a checkbox.<p>
+ *
+ * Note that the checkbox is NOT actually part of the field.  The checkbox is there if and only if
+ * the Table that the TableItem is part of, was created with SWT.CHECK.  When that is the case, the
+ * first column (id 0) of each TableItem will contain a checkbox.<p>
+ *
+ * If you make a "normal" column be your id-0 column, it will display the checkbox on the left, and
+ * then whatever is the content of the cell.<p>
+ *
+ * In order to give the appearance of a "checkbox column", we simply use an empty column.  The only
+ * thing interesting about this type of Field is how we get the "text value" for sorting: by looking
+ * at the status of the checkbox, of the <i>item</i>.  Again, the column does not actually have the
+ * checkbox; it's on the item.<p>
+ *
+ * In order for this to work, such a field can only be at position zero in the row (which, of course,
+ * also implies that there can only be one such field).  It must be created at position zero, and it
+ * must remain there.<p>
+ *
+ * This restriction is enforced in Column.createColumn().
+ */
+public class CheckboxField extends Field {
+
+    @SuppressWarnings("SameParameterValue")
+    CheckboxField(final String name, final String label) {
+        super(Field.Type.CHECKBOX, name, label);
+    }
+
+    public void setCellChecked(final TableItem item, final boolean isChecked) {
+        item.setChecked(isChecked);
+    }
+
+    @Override
+    public String getItemTextValue(final TableItem item) {
+        return (item.getChecked()) ? "0" : "1";
+    }
+}

--- a/src/main/org/tvrenamer/view/Column.java
+++ b/src/main/org/tvrenamer/view/Column.java
@@ -1,0 +1,159 @@
+package org.tvrenamer.view;
+
+import static org.eclipse.swt.SWT.*;
+
+import org.eclipse.swt.events.SelectionAdapter;
+import org.eclipse.swt.events.SelectionEvent;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+
+import java.util.logging.Logger;
+
+final class Column {
+    private static final Logger logger = Logger.getLogger(Column.class.getName());
+
+    final TableColumn swtColumn;
+    final Field field;
+    final int id;
+    @SuppressWarnings("CanBeFinal")
+    private Integer position = null;
+
+    private int sortDirection = UP;
+
+    /**
+     * Create a new Column object, from a TableColumn that's already been created.
+     * Private, to maintain the coupling between a Column and a TableColumn.  We
+     * only use TableColumns that were created by this class, via the createColumn
+     * static method, below.
+     *
+     * @param swtColumn
+     *    the actual TableColumn from the Table that this Column represents
+     * @param field
+     *    the Field that this Column is meant to display
+     * @param id
+     *    the order where the column was added to the table; also presumed to
+     *    be the initial position
+     */
+    private Column(TableColumn swtColumn, Field field, int id) {
+        this.swtColumn = swtColumn;
+        this.field = field;
+        this.id = id;
+        position = id;
+    }
+
+    /**
+     * Is this Column currently visible in the table?
+     *
+     * @return true if the Column is currently visible, false otherwise
+     */
+    @SuppressWarnings("SimplifiableIfStatement")
+    public boolean isVisible() {
+        if (swtColumn.isDisposed()) {
+            return false;
+        }
+        return (swtColumn.getWidth() > 0);
+    }
+
+    /**
+     * Get the Column from a TableColumn.
+     *
+     * @param tcol the TableColumn instance whose Column we want
+     * @return the Column that wraps the given TableColumn, or null if
+     *   something goes wrong
+     */
+    public static Column getColumnWrapper(final TableColumn tcol) {
+        Object columnObj = tcol.getData();
+        if (columnObj instanceof Column) {
+            return (Column) columnObj;
+        }
+        logger.warning("TableColumn's data is not a Column: " + columnObj);
+        return null;
+    }
+
+    /**
+     * Represent this Column as a String, displaying the field and position.
+     *
+     * @return a String representation of the Column
+     */
+    @Override
+    public String toString() {
+        return "Column [" + field + ", position=" + position + "]";
+    }
+
+    /**
+     * Creates a Column in the given table.  The only way to create a Column,
+     * as the constructor is private (by design).<p>
+     *
+     * Five arguments is kind of pushing it, but note they are five different
+     * types, so it wouldn't be possible to accidentally get them in the wrong
+     * order.<p>
+     *
+     * This method enforces the restriction that a CheckboxField may only be used
+     * for the first (id 0), column of the Table, and will be immovable if present.
+     * Please see comments in {@link CheckboxField}.java for an explanation.<p>
+     *
+     * There are no restrictions on Columns with other types of Fields.<p>
+     *
+     * This creates the TableColumn, and creates its behavior: when the user
+     * clicks on the header, the table is sorted by that column.  If the user
+     * clicks two or more times in a row on the same column, the effect is to
+     * reverse the search with each click.  A click on a different column always
+     * causes the new sort to be "up".<p>
+     *
+     * @param resultsTable
+     *     the {@link ResultsTable} that this Column belongs to
+     * @param swtTable
+     *     the SWT Table that this Column belongs to
+     * @param field
+     *     the {@link Field} that this Column displays
+     * @param label
+     *     the text to display in the header of this Column
+     * @param width
+     *     the initial width for this Column
+     * @return
+     *     a new Column created per the parameters given
+     */
+    public static Column createColumn(final ResultsTable resultsTable,
+                                      final Table swtTable,
+                                      final Field field,
+                                      final String label,
+                                      final int width)
+    {
+        final TableColumn tcol = new TableColumn(swtTable, NONE);
+
+        final int id = swtTable.indexOf(tcol);
+        if (id < 0) {
+            logger.severe("unable to locate column in table: " + tcol);
+            throw new IllegalStateException("could not locate column after adding it");
+        }
+        if (field.type == Field.Type.CHECKBOX) {
+            if (id > 0) {
+                throw new IllegalStateException("checkbox field can only be column zero");
+            }
+        }
+
+        final Column col = new Column(tcol, field, id);
+
+        tcol.setData(col);
+        tcol.setText(label);
+        tcol.setWidth(width);
+        tcol.addSelectionListener(new SelectionAdapter() {
+            @Override
+            public void widgetSelected(SelectionEvent e) {
+                final boolean sameColumn = (tcol == swtTable.getSortColumn());
+                if (sameColumn) {
+                    // If the last time we sorted, it was on THIS column,
+                    // then we reverse the direction of the previous sort.
+                    col.sortDirection = (col.sortDirection == DOWN) ? UP : DOWN;
+                } else {
+                    // If the last sort was on any other column, then we
+                    // sort UP.  We always sort UP on a "new" sort.
+                    col.sortDirection = UP;
+                }
+                resultsTable.sortTable(col, col.sortDirection);
+            }
+        });
+
+        return col;
+    }
+}

--- a/src/main/org/tvrenamer/view/ComboField.java
+++ b/src/main/org/tvrenamer/view/ComboField.java
@@ -1,0 +1,31 @@
+package org.tvrenamer.view;
+
+import org.eclipse.swt.widgets.Combo;
+import org.eclipse.swt.widgets.TableItem;
+
+public class ComboField extends TextField {
+
+    @SuppressWarnings("SameParameterValue")
+    ComboField(final String name, final String label) {
+        super(Field.Type.COMBO, name, label);
+    }
+
+    @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
+    private String itemDestDisplayedText(final TableItem item) {
+        synchronized (item) {
+            final Object data = item.getData();
+            if (data == null) {
+                return getCellText(item);
+            }
+            final Combo combo = (Combo) data;
+            final int selected = combo.getSelectionIndex();
+            final String[] options = combo.getItems();
+            return options[selected];
+        }
+    }
+
+    @Override
+    public String getItemTextValue(final TableItem item) {
+        return itemDestDisplayedText(item);
+    }
+}

--- a/src/main/org/tvrenamer/view/Field.java
+++ b/src/main/org/tvrenamer/view/Field.java
@@ -1,0 +1,118 @@
+package org.tvrenamer.view;
+
+import org.eclipse.swt.custom.TableEditor;
+import org.eclipse.swt.widgets.Control;
+import org.eclipse.swt.widgets.Table;
+import org.eclipse.swt.widgets.TableColumn;
+import org.eclipse.swt.widgets.TableItem;
+
+import java.util.logging.Logger;
+
+@SuppressWarnings("WeakerAccess")
+public abstract class Field {
+    private static final Logger logger = Logger.getLogger(Field.class.getName());
+
+    public enum Type {
+        CHECKBOX,
+        IMAGE,
+        TEXT,
+        COMBO
+    }
+
+    public final String name;
+    public final Type type;
+    public final String label;
+    protected Column column = null;
+
+    /**
+     * Constructs a new Field.
+     *
+     * @param type
+     *   the {@link Type} of the field to construct
+     * @param name
+     *   a String used for the name of this instance; it is only used in toString().<p>
+     *
+     *   Instances of Field are constant and are intended to be used like an Enum, but
+     *   Field needs too many features to actually use Enum.  A real Enum has the nice
+     *   feature that it can be printed and displays its variable name.  For a class
+     *   instance, we need to do this more explicitly to get it to work.
+     * @param label
+     *   the text to use in the header of a column that displays this Field
+     */
+    protected Field(final Type type, final String name, final String label) {
+        this.type = type;
+        this.name = name;
+        this.label = label;
+    }
+
+    /**
+     * Creates a new column associated with this Field.  This means both the
+     * TableColumn widget in the SWT Table, as well as our "Column" data
+     * structure that encapsulates it.  Does not return anything, but after
+     * it returns, the TableColumn can be retrieved via {@link #getTableColumn}.
+     *
+     * @param resultsTable
+     *    the instance of ResultsTable to create the column within
+     * @param swtTable
+     *    the SWT Table that the TableColumn will go into
+     * @param initialWidth
+     *    the width to create the column with
+     */
+    public void createColumn(final ResultsTable resultsTable,
+                             final Table swtTable,
+                             final int initialWidth)
+    {
+        if (this.column != null) {
+            logger.warning("cannot re-set column " + this);
+            throw new IllegalStateException("two columns created for " + this);
+        }
+        this.column = Column.createColumn(resultsTable, swtTable,
+                                          this, label, initialWidth);
+    }
+
+    /**
+     * Sets the editor on this Field of the given item, assuming that this Field is
+     * currently being shown.  Returns without error or comment if this Field is not
+     * currently displayed in the table.
+     *
+     * @param item
+     *    the row of the table on which to set the editor for this field
+     * @param editor
+     *    the TableEditor instance that provides the glue between the control and the item
+     * @param control
+     *    the widget to use to edit the cell value
+     */
+    public void setEditor(final TableItem item,
+                          final TableEditor editor,
+                          final Control control)
+    {
+        if ((column.isVisible()) && (!item.isDisposed())) {
+            editor.setEditor(control, item, column.id);
+        }
+    }
+
+    /**
+     * Retrieves the TableColumn associated with this Field, if there is one.
+     *
+     * @return the TableColumn associated with this Field, if there is one;
+     *    null if this Field is not currently being displayed in the table.
+     */
+    public TableColumn getTableColumn() {
+        if (column.isVisible()) {
+            return column.swtColumn;
+        }
+        return null;
+    }
+
+    public abstract String getItemTextValue(final TableItem item);
+
+    /**
+     * Represent this Field as a String
+     *
+     * @return a String representation of the Field
+     */
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/src/main/org/tvrenamer/view/Fields.java
+++ b/src/main/org/tvrenamer/view/Fields.java
@@ -1,0 +1,19 @@
+package org.tvrenamer.view;
+
+import static org.tvrenamer.model.util.Constants.*;
+
+import org.tvrenamer.model.UserPreferences;
+
+class Fields {
+    private static final UserPreferences prefs = UserPreferences.getInstance();
+
+    public static final CheckboxField CHECKBOX_FIELD
+        = new CheckboxField("CHECKBOX_FIELD", CHECKBOX_HEADER);
+    public static final TextField CURRENT_FILE_FIELD
+        = new TextField("CURRENT_FILE_FIELD", SOURCE_HEADER);
+    public static final ComboField NEW_FILENAME_FIELD
+        = new ComboField("NEW_FILENAME_FIELD",
+                         (prefs.isMoveEnabled() ? MOVE_HEADER : RENAME_HEADER));
+    public static final ImageField STATUS_FIELD
+        = new ImageField("STATUS_FIELD", STATUS_HEADER);
+}

--- a/src/main/org/tvrenamer/view/ImageField.java
+++ b/src/main/org/tvrenamer/view/ImageField.java
@@ -1,0 +1,80 @@
+package org.tvrenamer.view;
+
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.widgets.TableItem;
+
+import org.tvrenamer.model.util.Constants;
+
+public class ImageField extends Field {
+
+    @SuppressWarnings("SameParameterValue")
+    ImageField(final String name, final String label) {
+        super(Field.Type.IMAGE, name, label);
+    }
+
+    /**
+     * Sets the image to display in the given cell.
+     *
+     * @param item
+     *   the item to set the image of for this field
+     * @param newImage
+     *   the Image to display in this field, of the given item
+     */
+    public void setCellImage(final TableItem item, final Image newImage) {
+        if (column.isVisible() && (!item.isDisposed())) {
+            item.setImage(column.id, newImage);
+        }
+    }
+
+    /**
+     * Sets the image in the given cell to be the image that represents the given status.
+     *
+     * @param item
+     *   the item to set the image of for this field
+     * @param newStatus
+     *   the status of the item, from which we will obtain the Image to display
+     *   in this field, of the given item
+     */
+    public void setCellImage(final TableItem item, final ItemState newStatus) {
+        if (column.isVisible() && (!item.isDisposed())) {
+            item.setImage(column.id, newStatus.getIcon());
+        }
+    }
+
+    /**
+     * Gets the Image currently being displayed in the given cell.
+     *
+     * @param item
+     *   the item to get the text of for this field
+     * @return
+     *   the Image displayed this field, of the given item
+     */
+    public Image getCellImage(final TableItem item) {
+        if (column.isVisible()) {
+            return item.getImage(column.id);
+        }
+        return null;
+    }
+
+    /**
+     * Gets the "text" of the given cell, for sorting.
+     *
+     * In the case of a ImageField, we are currently assuming that the Image
+     * represents a status, and is provided by {@link ItemState}.  We send
+     * the Image object to ItemState, and ask it to map it to a String.
+     *
+     * @param item
+     *   the item to get the "text" of for this field
+     * @return
+     *   a text representing the status displayed this field, of the given item
+     */
+    @Override
+    public String getItemTextValue(final TableItem item) {
+        if (column.isVisible()) {
+            return ItemState.getImagePriority(item.getImage(column.id));
+        }
+        // Field not currently displayed in table
+        return Constants.EMPTY_STRING;
+    }
+
+}

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -1,6 +1,7 @@
 package org.tvrenamer.view;
 
 import static org.tvrenamer.model.util.Constants.*;
+import static org.tvrenamer.view.Fields.*;
 import static org.tvrenamer.view.ItemState.*;
 
 import org.eclipse.swt.SWT;
@@ -16,7 +17,6 @@ import org.eclipse.swt.events.KeyAdapter;
 import org.eclipse.swt.events.KeyEvent;
 import org.eclipse.swt.events.SelectionAdapter;
 import org.eclipse.swt.events.SelectionEvent;
-import org.eclipse.swt.graphics.Image;
 import org.eclipse.swt.layout.GridData;
 import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.layout.RowLayout;
@@ -74,11 +74,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     private static final Collator COLLATOR = Collator.getInstance(Locale.getDefault());
 
     private static final int ITEM_NOT_IN_TABLE = -1;
-
-    private static final int CHECKBOX_FIELD = 0;
-    private static final int CURRENT_FILE_FIELD = 1;
-    private static final int NEW_FILENAME_FIELD = 2;
-    private static final int STATUS_FIELD = 3;
 
     private static final int WIDTH_CHECKED = 10;
     private static final int WIDTH_CURRENT_FILE = 550;
@@ -142,54 +137,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         return new TableItem(swtTable, SWT.NONE);
     }
 
-    private static String getCellStatusString(final TableItem item, final int columnId) {
-        return ItemState.getImagePriority(item.getImage(columnId));
-    }
-
-    @SuppressWarnings("SameParameterValue")
-    private static Image getCellImage(final TableItem item, final int columnId) {
-        return item.getImage(columnId);
-    }
-
-    private static void setCellImage(final TableItem item,
-                                     final int columnId,
-                                     final Image newImage)
-    {
-        if (item.isDisposed()) {
-            return;
-        }
-        item.setImage(columnId, newImage);
-    }
-
-    private static void setCellStatus(final TableItem item,
-                                      final int columnId,
-                                      final ItemState newStatus)
-    {
-        setCellImage(item, columnId, newStatus.getIcon());
-    }
-
-    private static String getCellText(final TableItem item, final int columnId) {
-        return item.getText(columnId);
-    }
-
-    private static void setCellText(final TableItem item,
-                                    final int columnId,
-                                    final String newText)
-    {
-        if (item.isDisposed()) {
-            return;
-        }
-        item.setText(columnId, newText);
-    }
-
-    private static void setEditor(final TableItem item,
-                                  final int columnId,
-                                  final TableEditor editor,
-                                  final Control control)
-    {
-        editor.setEditor(control, item, columnId);
-    }
-
     private void setComboBoxProposedDest(final TableItem item, final FileEpisode ep) {
         if (swtTable.isDisposed() || item.isDisposed()) {
             return;
@@ -197,7 +144,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         final List<String> options = ep.getReplacementOptions();
         final int chosen = ep.getChosenEpisode();
         final String defaultOption = options.get(chosen);
-        setCellText(item, NEW_FILENAME_FIELD, defaultOption);
+        NEW_FILENAME_FIELD.setCellText(item, defaultOption);
 
         final Combo combo = newComboBox();
         if (combo == null) {
@@ -210,7 +157,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
 
         final TableEditor editor = new TableEditor(swtTable);
         editor.grabHorizontal = true;
-        setEditor(item, NEW_FILENAME_FIELD, editor, combo);
+        NEW_FILENAME_FIELD.setEditor(item, editor, combo);
     }
 
     private void deleteItemCombo(final TableItem item) {
@@ -244,24 +191,24 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         if (nOptions > 1) {
             setComboBoxProposedDest(item, ep);
         } else if (nOptions == 1) {
-            setCellText(item, NEW_FILENAME_FIELD, ep.getReplacementText());
+            NEW_FILENAME_FIELD.setCellText(item, ep.getReplacementText());
         } else {
-            setCellText(item, NEW_FILENAME_FIELD, ep.getReplacementText());
+            NEW_FILENAME_FIELD.setCellText(item, ep.getReplacementText());
             item.setChecked(false);
         }
     }
 
     private void failTableItem(final TableItem item) {
-        setCellStatus(item, STATUS_FIELD, FAIL);
+        STATUS_FIELD.setCellImage(item, FAIL);
         item.setChecked(false);
     }
 
     private void setTableItemStatus(final TableItem item, final int epsFound) {
         if (epsFound > 1) {
-            setCellStatus(item, STATUS_FIELD, OPTIONS);
+            STATUS_FIELD.setCellImage(item, OPTIONS);
             item.setChecked(true);
         } else if (epsFound == 1) {
-            setCellStatus(item, STATUS_FIELD, SUCCESS);
+            STATUS_FIELD.setCellImage(item, SUCCESS);
             item.setChecked(true);
         } else {
             failTableItem(item);
@@ -343,9 +290,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         // information about the episode to determine how to rename it, the check box will
         // automatically be activated.
         item.setChecked(false);
-        setCellText(item, CURRENT_FILE_FIELD, episode.getFilepath());
+        CURRENT_FILE_FIELD.setCellText(item, episode.getFilepath());
         setProposedDestColumn(item, episode);
-        setCellStatus(item, STATUS_FIELD, DOWNLOADING);
+        STATUS_FIELD.setCellImage(item, DOWNLOADING);
         return item;
     }
 
@@ -376,7 +323,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                         display.asyncExec(() -> {
                             if (tableContainsTableItem(item)) {
                                 setProposedDestColumn(item, episode);
-                                setCellStatus(item, STATUS_FIELD, ADDED);
+                                STATUS_FIELD.setCellImage(item, ADDED);
                             }
                         });
                         if (show.isValidSeries()) {
@@ -416,7 +363,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         Label progressLabel = new Label(swtTable, SWT.SHADOW_NONE | SWT.CENTER);
         TableEditor editor = new TableEditor(swtTable);
         editor.grabHorizontal = true;
-        setEditor(item, STATUS_FIELD, editor, progressLabel);
+        STATUS_FIELD.setEditor(item, editor, progressLabel);
 
         return progressLabel;
     }
@@ -430,7 +377,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         final List<FileMover> pendingMoves = new LinkedList<>();
         for (final TableItem item : swtTable.getItems()) {
             if (item.getChecked()) {
-                String fileName = getCellText(item, CURRENT_FILE_FIELD);
+                String fileName = CURRENT_FILE_FIELD.getCellText(item);
                 final FileEpisode episode = episodeMap.get(fileName);
                 // Skip files not successfully downloaded and ready to be moved
                 if (episode.optionCount() == 0) {
@@ -449,33 +396,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         swtTable.setFocus();
     }
 
-    @SuppressWarnings("SynchronizationOnLocalVariableOrMethodParameter")
-    private static String itemDestDisplayedText(final TableItem item) {
-        synchronized (item) {
-            final Object data = item.getData();
-            if (data == null) {
-                return getCellText(item, NEW_FILENAME_FIELD);
-            }
-            final Combo combo = (Combo) data;
-            final int selected = combo.getSelectionIndex();
-            final String[] options = combo.getItems();
-            return options[selected];
-        }
-    }
-
-    private static String getItemTextValue(final TableItem item, final int column) {
-        switch (column) {
-            case CHECKBOX_FIELD:
-                return (item.getChecked()) ? "0" : "1";
-            case STATUS_FIELD:
-                return getCellStatusString(item, column);
-            case NEW_FILENAME_FIELD:
-                return itemDestDisplayedText(item);
-            default:
-                return getCellText(item, column);
-        }
-    }
-
     /**
      * Insert a copy of the row at the given position, and then delete the original row.
      * Note that insertion does not overwrite the row that is already there.  It pushes
@@ -491,9 +411,9 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
 
         TableItem item = new TableItem(swtTable, SWT.NONE, positionToInsert);
         item.setChecked(wasChecked);
-        setCellText(item, CURRENT_FILE_FIELD, getCellText(oldItem, CURRENT_FILE_FIELD));
-        setCellText(item, NEW_FILENAME_FIELD, getCellText(oldItem, NEW_FILENAME_FIELD));
-        setCellImage(item, STATUS_FIELD, getCellImage(oldItem, STATUS_FIELD));
+        CURRENT_FILE_FIELD.setCellText(item, CURRENT_FILE_FIELD.getCellText(oldItem));
+        NEW_FILENAME_FIELD.setCellText(item, NEW_FILENAME_FIELD.getCellText(oldItem));
+        STATUS_FIELD.setCellImage(item, STATUS_FIELD.getCellImage(oldItem));
 
         final Object itemData = oldItem.getData();
 
@@ -503,7 +423,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         if (itemData != null) {
             final TableEditor newEditor = new TableEditor(swtTable);
             newEditor.grabHorizontal = true;
-            setEditor(item, NEW_FILENAME_FIELD, newEditor, (Control) itemData);
+            NEW_FILENAME_FIELD.setEditor(item, newEditor, (Control) itemData);
             item.setData(itemData);
         }
     }
@@ -512,23 +432,21 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
      * Sort the table by the given column in the given direction.
      *
      * @param column
-     *    the TableColumn to sort by
-     * @param columnNum
-     *    the position of the TableColumn in the Table
+     *    the Column to sort by
      * @param sortDirection
      *    the direction to sort by; SWT.UP means sort A-Z, while SWT.DOWN is Z-A
      */
-    private void sortTable(final TableColumn column, final int columnNum,
-                           final int sortDirection)
-    {
+    void sortTable(final Column column, final int sortDirection) {
+        Field field = column.field;
+
         // Get the items
         TableItem[] items = swtTable.getItems();
 
         // Go through the item list and bubble rows up to the top as appropriate
         for (int i = 1; i < items.length; i++) {
-            String value1 = getItemTextValue(items[i], columnNum);
+            String value1 = field.getItemTextValue(items[i]);
             for (int j = 0; j < i; j++) {
-                String value2 = getItemTextValue(items[j], columnNum);
+                String value2 = field.getItemTextValue(items[j]);
                 // Compare the two values and order accordingly
                 int comparison = COLLATOR.compare(value1, value2);
                 if (((comparison < 0) && (sortDirection == SWT.UP))
@@ -544,30 +462,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             }
         }
         swtTable.setSortDirection(sortDirection);
-        swtTable.setSortColumn(column);
-    }
-
-    /**
-     * Sort the table by the given column.
-     *
-     * If the column to sort by is the same column that the table is already
-     * sorted by, then the effect is to reverse the ordering of the sort.
-     *
-     * @param column
-     *    the TableColumn to sort by
-     */
-    private void sortTable(final TableColumn column) {
-        final int columnNum = swtTable.indexOf(column);
-        if (ITEM_NOT_IN_TABLE == columnNum) {
-            logger.severe("unable to locate column in table: " + column);
-            return;
-        }
-        int sortDirection = SWT.UP;
-        TableColumn previousSort = swtTable.getSortColumn();
-        if (column.equals(previousSort)) {
-            sortDirection = swtTable.getSortDirection() == SWT.DOWN ? SWT.UP : SWT.DOWN;
-        }
-        sortTable(column, columnNum, sortDirection);
+        swtTable.setSortColumn(column.swtColumn);
     }
 
     /**
@@ -587,7 +482,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     public void refreshDestinations() {
         logger.info("Refreshing destinations");
         for (TableItem item : swtTable.getItems()) {
-            String fileName = getCellText(item, CURRENT_FILE_FIELD);
+            String fileName = CURRENT_FILE_FIELD.getCellText(item);
             String newFileName = episodeMap.currentLocationOf(fileName);
             if (newFileName == null) {
                 // Not expected, but could happen, primarily if some other,
@@ -646,8 +541,10 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     }
 
     private void setColumnDestText() {
-        final TableColumn destinationColumn = swtTable.getColumn(NEW_FILENAME_FIELD);
-        if (prefs.isMoveSelected()) {
+        final TableColumn destinationColumn = NEW_FILENAME_FIELD.getTableColumn();
+        if (destinationColumn == null) {
+            logger.warning("could not get destination column");
+        } else if (prefs.isMoveSelected()) {
             destinationColumn.setText(MOVE_HEADER);
         } else {
             destinationColumn.setText(RENAME_HEADER);
@@ -656,7 +553,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
 
     private void deleteTableItem(final TableItem item) {
         deleteItemCombo(item);
-        episodeMap.remove(getCellText(item, CURRENT_FILE_FIELD));
+        episodeMap.remove(CURRENT_FILE_FIELD.getCellText(item));
         item.dispose();
     }
 
@@ -739,7 +636,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             if (item.isDisposed()) {
                 return;
             }
-            String fileName = getCellText(item, CURRENT_FILE_FIELD);
+            String fileName = CURRENT_FILE_FIELD.getCellText(item);
             String newLocation = episodeMap.currentLocationOf(fileName);
             if (newLocation == null) {
                 // Not expected, but could happen, primarily if some other,
@@ -748,7 +645,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
                 return;
             }
             if (!fileName.equals(newLocation)) {
-                setCellText(item, CURRENT_FILE_FIELD, newLocation);
+                CURRENT_FILE_FIELD.setCellText(item, newLocation);
             }
         }
     }
@@ -935,44 +832,20 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     }
 
     private synchronized void createColumns() {
-        final TableColumn checkboxColumn = new TableColumn(swtTable, SWT.LEFT, CHECKBOX_FIELD);
-        checkboxColumn.setText(CHECKBOX_HEADER);
-        checkboxColumn.setWidth(WIDTH_CHECKED);
-        checkboxColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(checkboxColumn);
-            }
-        });
+        CHECKBOX_FIELD.createColumn(this, swtTable, WIDTH_CHECKED);
+        CURRENT_FILE_FIELD.createColumn(this, swtTable, WIDTH_CURRENT_FILE);
+        NEW_FILENAME_FIELD.createColumn(this, swtTable, WIDTH_NEW_FILENAME);
+        STATUS_FIELD.createColumn(this, swtTable, WIDTH_STATUS);
+    }
 
-        final TableColumn sourceColumn = new TableColumn(swtTable, SWT.LEFT, CURRENT_FILE_FIELD);
-        sourceColumn.setText(SOURCE_HEADER);
-        sourceColumn.setWidth(WIDTH_CURRENT_FILE);
-        sourceColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(sourceColumn);
-            }
-        });
-
-        final TableColumn destinationColumn = new TableColumn(swtTable, SWT.LEFT, NEW_FILENAME_FIELD);
-        destinationColumn.setWidth(WIDTH_NEW_FILENAME);
-        destinationColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(destinationColumn);
-            }
-        });
-
-        final TableColumn statusColumn = new TableColumn(swtTable, SWT.LEFT, STATUS_FIELD);
-        statusColumn.setText(STATUS_HEADER);
-        statusColumn.setWidth(WIDTH_STATUS);
-        statusColumn.addSelectionListener(new SelectionAdapter() {
-            @Override
-            public void widgetSelected(SelectionEvent e) {
-                sortTable(statusColumn);
-            }
-        });
+    private void setSortColumn() {
+        TableColumn sortColumn = CURRENT_FILE_FIELD.getTableColumn();
+        if (sortColumn == null) {
+            logger.warning("could not find preferred sort column");
+        } else {
+            swtTable.setSortColumn(sortColumn);
+            swtTable.setSortDirection(SWT.UP);
+        }
     }
 
     private void setupResultsTable() {
@@ -986,8 +859,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
 
         createColumns();
         setColumnDestText();
-        swtTable.setSortColumn(swtTable.getColumn(CURRENT_FILE_FIELD));
-        swtTable.setSortDirection(SWT.UP);
+        setSortColumn();
 
         // Allow deleting of elements
         swtTable.addKeyListener(new KeyAdapter() {

--- a/src/main/org/tvrenamer/view/TextField.java
+++ b/src/main/org/tvrenamer/view/TextField.java
@@ -1,0 +1,62 @@
+package org.tvrenamer.view;
+
+import org.eclipse.swt.widgets.TableItem;
+
+import org.tvrenamer.model.util.Constants;
+
+public class TextField extends Field {
+
+    TextField(final Type type, final String name, final String label) {
+        super(type, name, label);
+    }
+
+    @SuppressWarnings("SameParameterValue")
+    TextField(final String name, final String label) {
+        this(Field.Type.TEXT, name, label);
+    }
+
+    /**
+     * Sets the text to display in the given cell.
+     *
+     * @param item
+     *   the item to set the text of for this field
+     * @param newText
+     *   the text to display in this field, of the given item
+     */
+    public void setCellText(final TableItem item, final String newText) {
+        if (column.isVisible() && (!item.isDisposed())) {
+            item.setText(column.id, newText);
+        }
+    }
+
+    /**
+     * Gets the text currently being displayed in the given cell.
+     *
+     * @param item
+     *   the item to get the text of for this field
+     * @return
+     *   the text displayed this field, of the given item
+     */
+    public String getCellText(final TableItem item) {
+        if (column.isVisible()) {
+            return item.getText(column.id);
+        }
+        return Constants.EMPTY_STRING;
+    }
+
+    /**
+     * Gets the "text" of the given cell, for sorting.
+     *
+     * In the case of a TextField, the "text" of the cell really is just that.
+     * (For other types of cells, it's more complicated.)
+     *
+     * @param item
+     *   the item to get the text of for this field
+     * @return
+     *   the text displayed this field, of the given item
+     */
+    @Override
+    public String getItemTextValue(final TableItem item) {
+        return getCellText(item);
+    }
+}


### PR DESCRIPTION
Add seven new classes:

- `Field.java` - an abstract class that defines a **field**, i.e., a piece of data that we may display in the table, once per row
- `TextField.java`, `ImageField.java`, `ComboField.java`, `CheckboxField.java`: subclasses of `Field.java`, which are intended to hold specific types of data, with specialized methods for those types
- `Fields.java` - defines the fields of the program as public static instances of `Field`
- `Column.java` - a `Column` is what is used to display a `Field`.  Our `Column` class encapsulates `TableColumn`, the actual UI class that is part of the table.  We are able to keep some other helpful data in the `Column` class, too.

A `Column` must be associated with a `Field`.  It's required in the constructor, and is final.  A `Field` can either have a null column (indicating it is not currently displayed in the `Table`), or can have one `Column`, which must refer back to the `Field`.

It is an error to try to assign a `Column` to a `Field` that already has a `Column`, or to try to assign a `Column` to a `Field` where that `Column` already refers to a different `Field`.

In addition to the seven new classes, we make major changes to `ResultsTable.java`:
- The fields had previously been defined as integer constants, whose values corresponded to the column IDs.  The column IDs are created by the `Table`, when the columns are added to it.  So, the definitions required "knowing" the order in which the code added them.  Now we import the Fields from `Fields.java`.
- All the cell get/set methods from `ResultsTable` now become methods on the Field.  `ResultsTable` no longer deals with Images; that's too level.  It just deals with the `ItemState`, and the `ImageField` turns that into an actual Image.
- Methods used for sorting, `itemDestDisplayedText` and `getItemTextValue`, previously were static methods defined in `ResultsTable`, which had to do some checking/dispatching depending on the type of the field.  Now the functionality lives in the `Field` classes, and is specific to the subclass of `Field` that is being used.
- The `sortTable` method no longer takes a `TableColumn` and a column ID; those two pieces of data are now encapsulated within the new `Column` class, which is what we pass, instead.
- Move the column creation call into the `Field`.  We create the column by asking the `Field` to do it.  In turn, it calls into Column, which can also define the selection behavior (sort by _this_ column)
- Therefore, we no longer need the `sortTable` wrapper method; the code that creates the Column knows how to figure out the sortDirection.
- We also add `getTableColumn()` to `Field`, and use it instead of `Table.getColumn().`  `Field.getTableColumn()` could return null, under the idea that we may define Fields that the user chooses not to display in the Table.  That is currently not supported, but it's something I intend to add.
