### PR TITLE
Create menus in UIStarter, other cleanup

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -221,7 +221,7 @@
       </packageset>
 
       <doctitle><![CDATA[<h1>TVRenamer</h1>]]></doctitle>
-      <bottom><![CDATA[<i>Copyright &#169; 2017 TVRenamer.org. All Rights Reserved.</i>]]></bottom>
+      <bottom><![CDATA[<i>Copyright &#169; 2018 TVRenamer.org. All Rights Reserved.</i>]]></bottom>
       <link href="http://docs.oracle.com/javase/8/docs/api/"/>
     </javadoc>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -208,6 +208,7 @@
 
   <target name="javadoc">
     <javadoc destdir="docs/api"
+             noqualifier="all"
              author="true"
              version="true"
              use="true"

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -7,6 +7,7 @@
 
 package org.tvrenamer.model;
 
+import static org.tvrenamer.model.ReplacementToken.*;
 import static org.tvrenamer.model.util.Constants.*;
 
 import org.tvrenamer.controller.FilenameParser;
@@ -644,21 +645,21 @@ public class FileEpisode {
             episodeTitle = episodeTitle.substring(0, MAX_TITLE_LENGTH);
         }
         String newFilename = replacementTemplate
-            .replaceAll(ReplacementToken.SEASON_NUM.getToken(),
+            .replaceAll(SEASON_NUM.getToken(),
                         String.valueOf(placement.season))
-            .replaceAll(ReplacementToken.SEASON_NUM_LEADING_ZERO.getToken(),
+            .replaceAll(SEASON_NUM_LEADING_ZERO.getToken(),
                         StringUtils.zeroPadTwoDigits(placement.season))
-            .replaceAll(ReplacementToken.EPISODE_NUM.getToken(),
+            .replaceAll(EPISODE_NUM.getToken(),
                         StringUtils.formatDigits(placement.episode))
-            .replaceAll(ReplacementToken.EPISODE_NUM_LEADING_ZERO.getToken(),
+            .replaceAll(EPISODE_NUM_LEADING_ZERO.getToken(),
                         StringUtils.zeroPadThreeDigits(placement.episode))
-            .replaceAll(ReplacementToken.SHOW_NAME.getToken(),
+            .replaceAll(SHOW_NAME.getToken(),
                         Matcher.quoteReplacement(showName))
-            .replaceAll(ReplacementToken.EPISODE_TITLE.getToken(),
+            .replaceAll(EPISODE_TITLE.getToken(),
                         Matcher.quoteReplacement(episodeTitle))
-            .replaceAll(ReplacementToken.EPISODE_TITLE_NO_SPACES.getToken(),
+            .replaceAll(EPISODE_TITLE_NO_SPACES.getToken(),
                         Matcher.quoteReplacement(StringUtils.makeDotTitle(episodeTitle)))
-            .replaceAll(ReplacementToken.EPISODE_RESOLUTION.getToken(),
+            .replaceAll(EPISODE_RESOLUTION.getToken(),
                         resolution);
 
         // Date and times
@@ -703,25 +704,22 @@ public class FileEpisode {
         // Date and times
         if (airDate == null) {
             return removeTokens(template,
-                                ReplacementToken.DATE_DAY_NUM,
-                                ReplacementToken.DATE_DAY_NUMLZ,
-                                ReplacementToken.DATE_MONTH_NUM,
-                                ReplacementToken.DATE_MONTH_NUMLZ,
-                                ReplacementToken.DATE_YEAR_FULL,
-                                ReplacementToken.DATE_YEAR_MIN);
+                                DATE_DAY_NUM, DATE_DAY_NUMLZ,
+                                DATE_MONTH_NUM, DATE_MONTH_NUMLZ,
+                                DATE_YEAR_FULL, DATE_YEAR_MIN);
         } else {
             return template
-                .replaceAll(ReplacementToken.DATE_DAY_NUM.getToken(),
+                .replaceAll(DATE_DAY_NUM.getToken(),
                             formatDate(airDate, "d"))
-                .replaceAll(ReplacementToken.DATE_DAY_NUMLZ.getToken(),
+                .replaceAll(DATE_DAY_NUMLZ.getToken(),
                             formatDate(airDate, "dd"))
-                .replaceAll(ReplacementToken.DATE_MONTH_NUM.getToken(),
+                .replaceAll(DATE_MONTH_NUM.getToken(),
                             formatDate(airDate, "M"))
-                .replaceAll(ReplacementToken.DATE_MONTH_NUMLZ.getToken(),
+                .replaceAll(DATE_MONTH_NUMLZ.getToken(),
                             formatDate(airDate, "MM"))
-                .replaceAll(ReplacementToken.DATE_YEAR_FULL.getToken(),
+                .replaceAll(DATE_YEAR_FULL.getToken(),
                             formatDate(airDate, "yyyy"))
-                .replaceAll(ReplacementToken.DATE_YEAR_MIN.getToken(),
+                .replaceAll(DATE_YEAR_MIN.getToken(),
                             formatDate(airDate, "yy"));
         }
     }

--- a/src/main/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/org/tvrenamer/model/FileEpisode.java
@@ -674,6 +674,15 @@ public class FileEpisode {
         return StringUtils.sanitiseTitle(newFilename);
     }
 
+    private static String removeTokens(final String orig, final ReplacementToken... tokens) {
+        String removed = orig;
+
+        for (ReplacementToken token : tokens) {
+            removed = removed.replaceAll(token.getToken(), "");
+        }
+        return removed;
+    }
+
     /**
      * Replace the date control strings in the template, with the episode air date information.
      * May be called with null if the episode in question doesn't have air date information.
@@ -693,13 +702,13 @@ public class FileEpisode {
     static String plugInAirDate(final LocalDate airDate, final String template) {
         // Date and times
         if (airDate == null) {
-            return template
-                .replaceAll(ReplacementToken.DATE_DAY_NUM.getToken(), "")
-                .replaceAll(ReplacementToken.DATE_DAY_NUMLZ.getToken(), "")
-                .replaceAll(ReplacementToken.DATE_MONTH_NUM.getToken(), "")
-                .replaceAll(ReplacementToken.DATE_MONTH_NUMLZ.getToken(), "")
-                .replaceAll(ReplacementToken.DATE_YEAR_FULL.getToken(), "")
-                .replaceAll(ReplacementToken.DATE_YEAR_MIN.getToken(), "");
+            return removeTokens(template,
+                                ReplacementToken.DATE_DAY_NUM,
+                                ReplacementToken.DATE_DAY_NUMLZ,
+                                ReplacementToken.DATE_MONTH_NUM,
+                                ReplacementToken.DATE_MONTH_NUMLZ,
+                                ReplacementToken.DATE_YEAR_FULL,
+                                ReplacementToken.DATE_YEAR_MIN);
         } else {
             return template
                 .replaceAll(ReplacementToken.DATE_DAY_NUM.getToken(),

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -461,6 +461,14 @@ class PreferencesDialog extends Dialog {
         item.setControl(generalGroup);
     }
 
+    private void addStringsToList(final List guiList,
+                                  final ReplacementToken... tokens)
+    {
+        for (ReplacementToken token : tokens) {
+            guiList.add(token.toString());
+        }
+    }
+
     private void createRenameTab() {
         TabItem item = new TabItem(tabFolder, SWT.NULL);
         item.setText(RENAMING_LABEL);
@@ -476,20 +484,21 @@ class PreferencesDialog extends Dialog {
         List renameTokensList = new List(replacementGroup, SWT.SINGLE);
         renameTokensList.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
                                                     true, true, 2, 1));
-        renameTokensList.add(ReplacementToken.SHOW_NAME.toString());
-        renameTokensList.add(ReplacementToken.SEASON_NUM.toString());
-        renameTokensList.add(ReplacementToken.SEASON_NUM_LEADING_ZERO.toString());
-        renameTokensList.add(ReplacementToken.EPISODE_NUM.toString());
-        renameTokensList.add(ReplacementToken.EPISODE_NUM_LEADING_ZERO.toString());
-        renameTokensList.add(ReplacementToken.EPISODE_TITLE.toString());
-        renameTokensList.add(ReplacementToken.EPISODE_TITLE_NO_SPACES.toString());
-        renameTokensList.add(ReplacementToken.EPISODE_RESOLUTION.toString());
-        renameTokensList.add(ReplacementToken.DATE_DAY_NUM.toString());
-        renameTokensList.add(ReplacementToken.DATE_DAY_NUMLZ.toString());
-        renameTokensList.add(ReplacementToken.DATE_MONTH_NUM.toString());
-        renameTokensList.add(ReplacementToken.DATE_MONTH_NUMLZ.toString());
-        renameTokensList.add(ReplacementToken.DATE_YEAR_MIN.toString());
-        renameTokensList.add(ReplacementToken.DATE_YEAR_FULL.toString());
+        addStringsToList(renameTokensList,
+                         ReplacementToken.SHOW_NAME,
+                         ReplacementToken.SEASON_NUM,
+                         ReplacementToken.SEASON_NUM_LEADING_ZERO,
+                         ReplacementToken.EPISODE_NUM,
+                         ReplacementToken.EPISODE_NUM_LEADING_ZERO,
+                         ReplacementToken.EPISODE_TITLE,
+                         ReplacementToken.EPISODE_TITLE_NO_SPACES,
+                         ReplacementToken.EPISODE_RESOLUTION,
+                         ReplacementToken.DATE_DAY_NUM,
+                         ReplacementToken.DATE_DAY_NUMLZ,
+                         ReplacementToken.DATE_MONTH_NUM,
+                         ReplacementToken.DATE_MONTH_NUMLZ,
+                         ReplacementToken.DATE_YEAR_MIN,
+                         ReplacementToken.DATE_YEAR_FULL);
 
         Label episodeTitleLabel = new Label(replacementGroup, SWT.NONE);
         episodeTitleLabel.setText(RENAME_FORMAT_TEXT);

--- a/src/main/org/tvrenamer/view/PreferencesDialog.java
+++ b/src/main/org/tvrenamer/view/PreferencesDialog.java
@@ -1,5 +1,6 @@
 package org.tvrenamer.view;
 
+import static org.tvrenamer.model.ReplacementToken.*;
 import static org.tvrenamer.model.util.Constants.*;
 
 import org.eclipse.swt.SWT;
@@ -485,20 +486,11 @@ class PreferencesDialog extends Dialog {
         renameTokensList.setLayoutData(new GridData(GridData.BEGINNING, GridData.CENTER,
                                                     true, true, 2, 1));
         addStringsToList(renameTokensList,
-                         ReplacementToken.SHOW_NAME,
-                         ReplacementToken.SEASON_NUM,
-                         ReplacementToken.SEASON_NUM_LEADING_ZERO,
-                         ReplacementToken.EPISODE_NUM,
-                         ReplacementToken.EPISODE_NUM_LEADING_ZERO,
-                         ReplacementToken.EPISODE_TITLE,
-                         ReplacementToken.EPISODE_TITLE_NO_SPACES,
-                         ReplacementToken.EPISODE_RESOLUTION,
-                         ReplacementToken.DATE_DAY_NUM,
-                         ReplacementToken.DATE_DAY_NUMLZ,
-                         ReplacementToken.DATE_MONTH_NUM,
-                         ReplacementToken.DATE_MONTH_NUMLZ,
-                         ReplacementToken.DATE_YEAR_MIN,
-                         ReplacementToken.DATE_YEAR_FULL);
+                         SHOW_NAME, SEASON_NUM, SEASON_NUM_LEADING_ZERO,
+                         EPISODE_NUM, EPISODE_NUM_LEADING_ZERO,
+                         EPISODE_TITLE, EPISODE_TITLE_NO_SPACES, EPISODE_RESOLUTION,
+                         DATE_DAY_NUM, DATE_DAY_NUMLZ, DATE_MONTH_NUM, DATE_MONTH_NUMLZ,
+                         DATE_YEAR_MIN, DATE_YEAR_FULL);
 
         Label episodeTitleLabel = new Label(replacementGroup, SWT.NONE);
         episodeTitleLabel.setText(RENAME_FORMAT_TEXT);

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -858,20 +858,11 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             @Override
             public void keyReleased(KeyEvent e) {
                 super.keyReleased(e);
-
-                switch (e.keyCode) {
-
-                    // backspace
-                    case '\u0008':
-                    // delete
-                    case '\u007F':
-                        deleteSelectedTableItems();
-                        break;
-
-                    // Code analysis says have a default clause...
-                    default:
+                if ((e.keyCode == '\u0008') // backspace
+                    || (e.keyCode == '\u007F')) // delete
+                {
+                    deleteSelectedTableItems();
                 }
-
             }
         });
 

--- a/src/main/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/org/tvrenamer/view/ResultsTable.java
@@ -29,9 +29,6 @@ import org.eclipse.swt.widgets.Display;
 import org.eclipse.swt.widgets.FileDialog;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.swt.widgets.Link;
-import org.eclipse.swt.widgets.Listener;
-import org.eclipse.swt.widgets.Menu;
-import org.eclipse.swt.widgets.MenuItem;
 import org.eclipse.swt.widgets.ProgressBar;
 import org.eclipse.swt.widgets.Shell;
 import org.eclipse.swt.widgets.Table;
@@ -56,7 +53,6 @@ import org.tvrenamer.model.Show;
 import org.tvrenamer.model.ShowStore;
 import org.tvrenamer.model.UserPreference;
 import org.tvrenamer.model.UserPreferences;
-import org.tvrenamer.model.util.Environment;
 
 import java.text.Collator;
 import java.util.LinkedList;
@@ -688,10 +684,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         }
     }
 
-    private void quit() {
-        shell.dispose();
-    }
-
     private void setupUpdateStuff(final Composite parentComposite) {
         Link updatesAvailableLink = new Link(parentComposite, SWT.VERTICAL);
         // updatesAvailableLink.setLayoutData(new GridData(SWT.RIGHT, SWT.CENTER, true, true));
@@ -768,7 +760,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         quitButton.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                quit();
+                ui.quit();
             }
         });
 
@@ -905,74 +897,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         }
     }
 
-    private void makeMenuItem(final Menu parent, final String text,
-                              final Listener listener, final char shortcut)
-    {
-        MenuItem newItem = new MenuItem(parent, SWT.PUSH);
-        newItem.setText(text + "\tCtrl+" + shortcut);
-        newItem.addListener(SWT.Selection, listener);
-        newItem.setAccelerator(SWT.CONTROL | shortcut);
-    }
-
-    private Menu setupHelpMenuBar(final Menu menuBar) {
-        MenuItem helpMenuHeader = new MenuItem(menuBar, SWT.CASCADE);
-        helpMenuHeader.setText("Help");
-
-        Menu helpMenu = new Menu(shell, SWT.DROP_DOWN);
-        helpMenuHeader.setMenu(helpMenu);
-
-        MenuItem helpHelpItem = new MenuItem(helpMenu, SWT.PUSH);
-        helpHelpItem.setText("Help");
-
-        MenuItem helpVisitWebPageItem = new MenuItem(helpMenu, SWT.PUSH);
-        helpVisitWebPageItem.setText("Visit Web Page");
-        helpVisitWebPageItem.addSelectionListener(new UrlLauncher(TVRENAMER_PROJECT_URL));
-
-        return helpMenu;
-    }
-
-    private void setupMenuBar() {
-        Menu menuBarMenu = new Menu(shell, SWT.BAR);
-        Menu helpMenu;
-
-        Listener preferencesListener = e -> {
-            PreferencesDialog preferencesDialog = new PreferencesDialog(shell);
-            preferencesDialog.open();
-        };
-        Listener aboutListener = e -> {
-            AboutDialog aboutDialog = new AboutDialog(ui);
-            aboutDialog.open();
-        };
-        Listener quitListener = e -> quit();
-
-        if (Environment.IS_MAC_OSX) {
-            // Add the special Mac OSX Preferences, About and Quit menus.
-            CocoaUIEnhancer enhancer = new CocoaUIEnhancer();
-            enhancer.hookApplicationMenu(display, quitListener, aboutListener, preferencesListener);
-
-            setupHelpMenuBar(menuBarMenu);
-        } else {
-            // Add the normal Preferences, About and Quit menus.
-            MenuItem fileMenuItem = new MenuItem(menuBarMenu, SWT.CASCADE);
-            fileMenuItem.setText("File");
-
-            Menu fileMenu = new Menu(shell, SWT.DROP_DOWN);
-            fileMenuItem.setMenu(fileMenu);
-
-            makeMenuItem(fileMenu, PREFERENCES_LABEL, preferencesListener, 'P');
-            makeMenuItem(fileMenu, EXIT_LABEL, quitListener, 'Q');
-
-            helpMenu = setupHelpMenuBar(menuBarMenu);
-
-            // The About item is added to the OSX bar, so we need to add it manually here
-            MenuItem helpAboutItem = new MenuItem(helpMenu, SWT.PUSH);
-            helpAboutItem.setText("About");
-            helpAboutItem.addListener(SWT.Selection, aboutListener);
-        }
-
-        shell.setMenuBar(menuBarMenu);
-    }
-
     ResultsTable(final UIStarter ui) {
         this.ui = ui;
         shell = ui.shell;
@@ -981,6 +905,5 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         setupTopButtons();
         swtTable = new Table(shell, SWT.CHECK | SWT.FULL_SELECTION | SWT.MULTI);
         setupMainWindow();
-        setupMenuBar();
     }
 }


### PR DESCRIPTION
Some more cleanup-type changes.

Add noqualifier="all" to javadoc generation.  Now we get things like "String" instead of "java.lang.String".  Update copyright year for javadoc.

Change how we handle ReplacementTokens in a few ways, to try to make the code simpler.

Fairly recently, I split up UIStarter.java into two files.  I created ResultsTable.java to break out the functionality that was specific to the table.  I included the menu generation, which I should not have; that is more generic and better fits in UIStarter.  Now UIStarter does things like initialize the Cocoa functionality, which makes a lot more sense than having a class that represents a Table do it.

Replace "switch" statement with "if".  We only had two cases, and only one action.  It's much simpler as an "if".