### PR TITLE
Fix tvrenamer/tvrenamer#269 tvrenamer/tvrenamer#353 tvrenamer/tvrenamer#324

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--suppress ALL -->
 <project name="TVRenamer build script" default="usage"
+         xmlns:fx="javafx:com.sun.javafx.tools.ant"
          xmlns:ivy="antlib:org.apache.ivy.ant">
 
   <property name="src.main" value="src/main" />
@@ -20,6 +21,9 @@
 
   <property name="version.file" value="${res}/tvrenamer.version" />
   <property name="logging.file" value="${res}/logging.properties" />
+
+  <property environment="env" />
+
   <loadfile property="version" srcFile="${version.file}">
     <filterchain>
       <striplinebreaks />
@@ -183,6 +187,46 @@
     </sequential>
   </macrodef>
 
+  <!-- Your environment variable JAVA_HOME must point to Java 8 or 10 SDK -->
+  <macrodef name="build.osx.javapackager" >
+    <attribute name="platform" />
+    <attribute name="swtid" />
+    <sequential>
+
+      <build.jar platform="@{platform}" swtid="@{swtid}" />
+
+      <taskdef
+        resource="com/sun/javafx/tools/ant/antlib.xml"
+        uri="javafx:com.sun.javafx.tools.ant"
+        classpath=".:${env.JAVA_HOME}/lib/ant-javafx.jar"/>
+
+      <fx:deploy
+        verbose="true"
+          embedjnlp="false"
+        outdir="${dist}"
+        outfile="TVRenamer"
+        nativeBundles="image">
+
+        <fx:info
+          title="TVRenamer"
+          vendor="TVRenamer"/>
+
+        <fx:application
+          name="${rel.name}"
+          mainClass="${jar.mainClass}" />
+
+        <fx:platform>
+          <fx:jvmarg value="-XstartOnFirstThread" />
+        </fx:platform>
+
+        <fx:resources>
+          <fx:fileset dir="${build.jar}/@{platform}" includes="tvrenamer.jar" />
+        </fx:resources>
+
+      </fx:deploy>
+    </sequential>
+  </macrodef>
+
   <macrodef name="build.win">
     <attribute name="platform" />
     <attribute name="swtid" />
@@ -222,6 +266,11 @@
   </target>
 
   <target name="dist.all" depends="init, resolve, dist.win, dist.linux, dist.osx" />
+
+  <target name="dist.osx.javapackager" depends="clean">
+    <build.osx.javapackager platform="osx32" swtid="cocoa.macosx" />
+    <build.osx.javapackager platform="osx64" swtid="cocoa.macosx.x86_64" />
+  </target>
 
   <target name="javadoc">
     <javadoc destdir="${jdoc}/api"


### PR DESCRIPTION
This patch adds an option to build TVRenamer app in macOS using Java 8, 10
`javapackager` that fixes some crashes in recent macOS versions. Note that,
this fix needs to set `JAVA_HOME` environment variable correctly to Java 8 or
10 JDK. Unfortunately, it does not work in Java 9 or 11 as `javapackager`has
been removed in these versions.

The command used to build with `javapackager`:

```
ant dist.osx.javapackager
```