### PR TITLE
Add support for three-digit seasons (#357)

### DIFF
--- a/src/main/java/org/tvrenamer/controller/FilenameParser.java
+++ b/src/main/java/org/tvrenamer/controller/FilenameParser.java
@@ -25,13 +25,13 @@ public class FilenameParser {
 
     private static final String[] REGEX = {
         // this one matches SXXEXX:
-        "(.+?[^a-zA-Z0-9]\\D*?)[sS](\\d\\d?)[eE](\\d\\d*).*",
+        "(.+?[^a-zA-Z0-9]\\D*?)[sS](\\d\\d*)[eE](\\d\\d*).*",
 
         // this one matches Season-XX-Episode-XX:
-        "(.+?[^a-zA-Z0-9]\\D*?)Season[- ](\\d\\d?)[- ]?Episode[- ](\\d\\d*).*",
+        "(.+?[^a-zA-Z0-9]\\D*?)Season[- ](\\d\\d*)[- ]?Episode[- ](\\d\\d*).*",
 
         // this one matches sXX.eXX:
-        "(.+[^a-zA-Z0-9]\\D*?)[sS](\\d\\d?)\\D*?[eE](\\d\\d).*",
+        "(.+[^a-zA-Z0-9]\\D*?)[sS](\\d\\d*)\\D*?[eE](\\d\\d*).*",
 
         // this one matches SSxEE, with an optional leading "S"
         "(.+[^a-zA-Z0-9]\\D*?)[Ss](\\d\\d?)x(\\d\\d\\d?).*",

--- a/src/test/java/org/tvrenamer/controller/FilenameParserTest.java
+++ b/src/test/java/org/tvrenamer/controller/FilenameParserTest.java
@@ -83,6 +83,38 @@ public class FilenameParserTest {
     }
 
     @BeforeClass
+    public static void setupValuesThreeDigitSeason() {
+        values.add(new EpisodeTestData.Builder()
+                   .inputFilename("House Hunters International.S103E02.mkv")
+                   .filenameShow("House Hunters International")
+                   .seasonNumString("103")
+                   .episodeNumString("02")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValuesLongThreeDigitSeason() {
+        values.add(new EpisodeTestData.Builder()
+                   .inputFilename("House Hunters International "
+                                  + "Season 103 Episode 2.mkv")
+                   .filenameShow("House Hunters International")
+                   .seasonNumString("103")
+                   .episodeNumString("02")
+                   .build());
+    }
+
+    @BeforeClass
+    public static void setupValuesDotThreeDigitSeason() {
+        values.add(new EpisodeTestData.Builder()
+                   .inputFilename("House.Hunters.International."
+                                  + "s103.e02.mkv")
+                   .filenameShow("House.Hunters.International")
+                   .seasonNumString("103")
+                   .episodeNumString("02")
+                   .build());
+    }
+
+    @BeforeClass
     public static void setupValues01() {
         values.add(new EpisodeTestData.Builder()
                    .inputFilename("game.of.thrones.5x01.mp4")


### PR DESCRIPTION
For certain more obscure formats, it's too tricky, but for the most common formats, which have clear delimiters, it's no problem to accept three-digit seasons.

We were given an example of a show that actually has over 100 seasons: House Hunters International.  Use it to add tests to confirm we are parsing such filenames correctly.

Also tested running the app with the example file.  It did work.  But it took a really, really long time to parse all the episodes.