### PR TITLE
Inform user of move failures (#376)

### DIFF
--- a/src/main/java/org/tvrenamer/controller/util/FileUtilities.java
+++ b/src/main/java/org/tvrenamer/controller/util/FileUtilities.java
@@ -146,7 +146,7 @@ public class FileUtilities {
         logger.info("craziest possible outcome");
         logger.info("src file gone, dest file not there, result of move call "
                     + "not null, but also not there.  Fubar.");
-        return null;
+        return actualDest;
     }
 
     /**
@@ -163,7 +163,7 @@ public class FileUtilities {
      * directly, is to detect specific problems and communicate them via
      * logging.  It is a wrapper around Files.move().
      *
-     * <p>If an unexpected result occurs, calls {@link unexpectedMoveResult}.
+     * <p>If an unexpected result occurs, calls {@link #unexpectedMoveResult}.
      *
      * @param srcFile
      *    the file to be renamed

--- a/src/main/java/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/java/org/tvrenamer/model/FileEpisode.java
@@ -468,6 +468,8 @@ public class FileEpisode {
      *
      * This information really is not currently used.
      *
+     * @param result
+     *   the result of the attempted move
      */
     public void setRenamed(final MoveStatus result) {
         fileStatus = result;
@@ -663,7 +665,16 @@ public class FileEpisode {
     }
 
     /**
-     * Returns the name of the file to which the file should be moved.<p>
+     * Returns the pathname to which the file should be moved.
+     *
+     * <p>Takes the base part of the name as an argument, resolves it in the
+     * destination directory, and returns it as a String.
+     *
+     * @param filename
+     *   the filename to which we should move the file associated with this
+     *   FileEpisode
+     * @return
+     *   the pathname to which we should move the file, as a String
      *
      */
     private String getMoveToFile(final String filename) {

--- a/src/main/java/org/tvrenamer/model/FileEpisode.java
+++ b/src/main/java/org/tvrenamer/model/FileEpisode.java
@@ -291,6 +291,10 @@ public class FileEpisode {
         return pathObj;
     }
 
+    public String getFileName() {
+        return fileNameString;
+    }
+
     private void checkFile(boolean mustExist) {
         if (Files.exists(pathObj)) {
             try {

--- a/src/main/java/org/tvrenamer/model/util/Constants.java
+++ b/src/main/java/org/tvrenamer/model/util/Constants.java
@@ -144,6 +144,9 @@ public class Constants {
     public static final String CANT_CREATE_DEST = "Unable to create the destination directory";
     public static final String MOVE_NOT_POSSIBLE = "You will not be able to actually move files "
         + "until this is corrected.  Open the Preferences dialog to correct it.";
+    public static final String MOVE_FAILURE_MSG_1 = "Some files were not moved";
+    public static final String MOVE_FAILURE_PARTIAL_MSG = ".  These include";
+    public static final String NEWLINE_BULLET = "\n\u2022 ";
     public static final String MOVE_INTRO = "Clicking this button will ";
     public static final String AND_RENAME = "rename and ";
     public static final String INTRO_MOVE_DIR = "move the checked files to the directory "

--- a/src/main/java/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/java/org/tvrenamer/view/ResultsTable.java
@@ -392,6 +392,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
             return;
         }
 
+        actionButton.setEnabled(false);
         renameFiles();
         swtTable.setFocus();
     }
@@ -602,6 +603,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
 
     void finishAllMoves() {
         ui.setAppIcon();
+        actionButton.setEnabled(true);
     }
 
     /*

--- a/src/main/java/org/tvrenamer/view/ResultsTable.java
+++ b/src/main/java/org/tvrenamer/view/ResultsTable.java
@@ -365,11 +365,6 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
     }
 
     private void renameFiles() {
-        if (!prefs.isMoveEnabled() && !prefs.isRenameSelected()) {
-            logger.info("move and rename both disabled, nothing to be done.");
-            return;
-        }
-
         final List<FileMover> pendingMoves = new LinkedList<>();
         for (final TableItem item : swtTable.getItems()) {
             if (item.getChecked()) {
@@ -389,6 +384,15 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         MoveRunner mover = new MoveRunner(pendingMoves);
         mover.setUpdater(new ProgressBarUpdater(this));
         mover.runThread();
+    }
+
+    private void executeActionButton() {
+        if (!prefs.isMoveEnabled() && !prefs.isRenameSelected()) {
+            logger.info("move and rename both disabled, nothing to be done.");
+            return;
+        }
+
+        renameFiles();
         swtTable.setFocus();
     }
 
@@ -774,7 +778,7 @@ public final class ResultsTable implements Observer, AddEpisodeListener {
         actionButton.addSelectionListener(new SelectionAdapter() {
             @Override
             public void widgetSelected(SelectionEvent e) {
-                renameFiles();
+                executeActionButton();
             }
         });
     }

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -1,5 +1,5 @@
 # The JDK logging properties file, intended for development only
-# Example from http://www.java2s.com/Code/Java/Language-Basics/ConfiguringLoggerDefaultValueswithaPropertiesFile.htm
+# Example from http://www.java2s.com/Code/Java/Language-Basics/ConfiguringLoggerDefaultValuesWithAPropertiesFile.htm
 
 # It is loaded by the Launcher class, in its static initialization block.  The build.xml ant file copies
 # this file to the right place so that the Launcher will be able to find it.


### PR DESCRIPTION
Prior to this, when we failed to move one or more files, there was no obvious indication given to the user.

(When a file IS successfully moved, the value displayed in CURRENT_FILE_FIELD changes, and also, if "Delete Rows After Move" is checked, the row is deleted. So, the fact that neither of those things happens with a failure is SOME indication of the failure, but it's not obvious.)

I'm using a modal dialog box, which is kind of aggressive.  I think it's justified in this case, but I want to make sure we don't show more than one per move operation.  As results come in, asynchronously, we store the failures into a data structure, and then once all moves have completed, if there were any failures, we construct the text for the dialog box and present it to the user.

This provides the basic functionality.  There is clearly more that could be done.

There are some other commits in this PR.  Please see individual commits.