### PR TITLE
Add conflict test

### DIFF
--- a/etc/nochecks.xml
+++ b/etc/nochecks.xml
@@ -5,15 +5,10 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-    <suppress files="src.test.java.org.tvrenamer.controller.FilenameParserTest.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.controller.MoveTest.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.controller.TheTVDBProviderTest.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.model.EpisodeTestData.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.model.FileEpisodeTest.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.controller.util.StringUtilsTest.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.controller.util.FileUtilsTest.java" checks="JavadocMethod"/>
-    <suppress files="src.test.java.org.tvrenamer.controller.TestMain.java" checks=".*"/>
+    <suppress files="src.test.*.java" checks="JavadocMethod"/>
 
-    <suppress files="src.main.java.org.tvrenamer.model.GlobalOverrides.java" checks="JavadocMethod"/>
-    <suppress files="src.main.java.org.tvrenamer.controller.util.XPathUtilities.java" checks="JavadocMethod"/>
+    <suppress files="TestMain.java" checks=".*"/>
+
+    <suppress files="GlobalOverrides.java" checks="JavadocMethod"/>
+    <suppress files="XPathUtilities.java" checks="JavadocMethod"/>
 </suppressions>

--- a/etc/nochecks.xml
+++ b/etc/nochecks.xml
@@ -5,15 +5,15 @@
     "http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 
 <suppressions>
-    <suppress files="src/test/java/org/tvrenamer/controller/FilenameParserTest.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/controller/MoveTest.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/controller/TheTVDBProviderTest.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/model/EpisodeTestData.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/model/FileEpisodeTest.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/controller/util/StringUtilsTest.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/controller/util/FileUtilsTest.java" checks="JavadocMethod"/>
-    <suppress files="src/test/java/org/tvrenamer/controller/TestMain.java" checks=".*"/>
+    <suppress files="src.test.java.org.tvrenamer.controller.FilenameParserTest.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.controller.MoveTest.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.controller.TheTVDBProviderTest.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.model.EpisodeTestData.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.model.FileEpisodeTest.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.controller.util.StringUtilsTest.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.controller.util.FileUtilsTest.java" checks="JavadocMethod"/>
+    <suppress files="src.test.java.org.tvrenamer.controller.TestMain.java" checks=".*"/>
 
-    <suppress files="src/main/java/org/tvrenamer/model/GlobalOverrides.java" checks="JavadocMethod"/>
-    <suppress files="src/main/java/org/tvrenamer/controller/util/XPathUtilities.java" checks="JavadocMethod"/>
+    <suppress files="src.main.java.org.tvrenamer.model.GlobalOverrides.java" checks="JavadocMethod"/>
+    <suppress files="src.main.java.org.tvrenamer.controller.util.XPathUtilities.java" checks="JavadocMethod"/>
 </suppressions>

--- a/src/main/java/org/tvrenamer/controller/FileMover.java
+++ b/src/main/java/org/tvrenamer/controller/FileMover.java
@@ -259,12 +259,15 @@ public class FileMover implements Callable<Boolean> {
     }
 
     /**
-     * Add a version string to the destination filename.
+     * Create the version string for the destination filename.
      *
      * @return destination filename with a version added
      */
-    private String addVersionString() {
-        return destBasename + " (" + destIndex + ")" + destSuffix;
+    String versionString() {
+        if (destIndex == null) {
+            return "";
+        }
+        return " (" + destIndex + ")";
     }
 
     /**
@@ -299,7 +302,7 @@ public class FileMover implements Callable<Boolean> {
             if (userPrefs.isMoveEnabled()) {
                 destDir = destRoot.resolve(DUPLICATES_DIRECTORY);
             }
-            filename = addVersionString();
+            filename =  destBasename + versionString() + destSuffix;
         }
 
         if (!FileUtilities.ensureWritableDirectory(destDir)) {

--- a/src/main/java/org/tvrenamer/controller/FileMover.java
+++ b/src/main/java/org/tvrenamer/controller/FileMover.java
@@ -81,17 +81,17 @@ public class FileMover implements Callable<Boolean> {
     }
 
     /**
-     * Gets the name of the directory we should move the file to, as a string.
+     * Gets the name of the directory we should move the file to, as a Path.
      *
      * We call it the "moveToDirectory" because "destinationDirectory" is used more
      * to refer to the top-level directory: the one the user specified in the dialog
      * for user preferences.  This is the subdirectory of that folder that the file
      * should actually be placed in.
      *
-     * @return the name of the directory we should move the file to, as a string.
+     * @return the directory we should move the file to, as a Path.
      */
-    String getMoveToDirectory() {
-        return destRoot.toString();
+    Path getMoveToDirectory() {
+        return destRoot;
     }
 
     /**

--- a/src/main/java/org/tvrenamer/controller/MoveRunner.java
+++ b/src/main/java/org/tvrenamer/controller/MoveRunner.java
@@ -227,8 +227,8 @@ public class MoveRunner implements Runnable {
         final Map<String, List<FileMover>> toMove = new HashMap<>();
 
         for (final FileMover pendingMove : episodes) {
-            String moveToDir = pendingMove.getMoveToDirectory();
-            List<FileMover> existingDirMoves = getListValue(toMove, moveToDir);
+            Path moveToDir = pendingMove.getMoveToDirectory();
+            List<FileMover> existingDirMoves = getListValue(toMove, moveToDir.toString());
             existingDirMoves.add(pendingMove);
         }
 

--- a/src/test/java/org/tvrenamer/controller/ConflictTest.java
+++ b/src/test/java/org/tvrenamer/controller/ConflictTest.java
@@ -1,0 +1,75 @@
+package org.tvrenamer.controller;
+
+import org.junit.Test;
+
+import org.tvrenamer.model.EpisodeTestData;
+import org.tvrenamer.model.util.Constants;
+
+import java.nio.file.Path;
+
+/**
+ * ConflictTest -- test file moving functionality when there is a conflict.
+ *
+ * The FileMover requires a FileEpisode, which has a whole bunch of information
+ * in it, which it obtains from various places, including the user preferences,
+ * the FilenameParser class, and the TVDB.  But we already have functionality
+ * to create a filled-in FileEpisode without relying on the parser or provider.
+ *
+ * It does still rely on the user preferences, so we are sure to set all the
+ * relevant settings.
+ *
+ * This class uses the TemporaryFolder functionality of jUnit to create and
+ * move files that will be automatically cleaned up after each test completes.
+ *
+ */
+public class ConflictTest extends MoveTest {
+
+    private static final EpisodeTestData bigBang0322 = new EpisodeTestData.Builder()
+        .inputFilename("big.bang.theory.322.mp4")
+        .filenameShow("big.bang.theory")
+        .properShowName("The Big Bang Theory")
+        .seasonNumString("3")
+        .episodeNumString("22")
+        .filenameSuffix(".mp4")
+        .episodeTitle("The Staircase Implementation")
+        .episodeId("2063661")
+        .replacementMask("%S S%0sE%0e %t")
+        .expectedReplacement("The Big Bang Theory S03E22 The Staircase Implementation")
+        .build();
+
+    private void makeConflict(final EpisodeTestData epdata,
+                              final FileMover mover)
+    {
+        Path baseDestDir = mover.getMoveToDirectory();
+        Path desiredDestDir = baseDestDir.resolve(Constants.DUPLICATES_DIRECTORY);
+        String desiredFilename = epdata.expectedReplacement
+            + mover.versionString()
+            + epdata.filenameSuffix;
+
+        // Create a file in the way, so that we will not be able to move the
+        // source file to the desired destination
+        TestUtils.createFile(desiredDestDir, desiredFilename);
+
+        if (mover.destIndex == null) {
+            mover.destIndex = 2;
+        } else {
+            mover.destIndex++;
+        }
+
+        expectedDest = desiredDestDir.resolve(desiredFilename);
+    }
+
+    @Test
+    public void testFileMoverConflict() {
+        setValues(bigBang0322);
+        assertReady();
+
+        FileMover mover = new FileMover(episode);
+        makeConflict(bigBang0322, mover);
+        mover.call();
+        long now = System.currentTimeMillis();
+
+        assertMoved();
+        assertTimestamp(now);
+    }
+}

--- a/src/test/java/org/tvrenamer/controller/ConflictTest.java
+++ b/src/test/java/org/tvrenamer/controller/ConflictTest.java
@@ -6,6 +6,9 @@ import org.tvrenamer.model.EpisodeTestData;
 import org.tvrenamer.model.util.Constants;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
 
 /**
  * ConflictTest -- test file moving functionality when there is a conflict.
@@ -71,5 +74,22 @@ public class ConflictTest extends MoveTest {
 
         assertMoved();
         assertTimestamp(now);
+    }
+
+    @Test
+    public void testMoveRunnerWithConflict() {
+        final CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        setValues(bigBang0322);
+        assertReady();
+
+        FileMover mover = new FileMover(episode);
+        makeConflict(bigBang0322, mover);
+        mover.addObserver(new FutureCompleter(future));
+
+        List<FileMover> moveList = new ArrayList<>();
+        moveList.add(mover);
+
+        executeMoveRunnerTest(moveList, future);
     }
 }

--- a/src/test/java/org/tvrenamer/controller/ConflictTest.java
+++ b/src/test/java/org/tvrenamer/controller/ConflictTest.java
@@ -92,4 +92,41 @@ public class ConflictTest extends MoveTest {
 
         executeMoveRunnerTest(moveList, future);
     }
+
+    @Test
+    public void testMoveRunnerWithTwoConflicts() {
+        final CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        setValues(bigBang0322);
+        assertReady();
+
+        FileMover mover = new FileMover(episode);
+        makeConflict(bigBang0322, mover);
+        makeConflict(bigBang0322, mover);
+        mover.addObserver(new FutureCompleter(future));
+
+        List<FileMover> moveList = new ArrayList<>();
+        moveList.add(mover);
+
+        executeMoveRunnerTest(moveList, future);
+    }
+
+    @Test
+    public void testMoveRunnerWithThreeConflicts() {
+        final CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        setValues(bigBang0322);
+        assertReady();
+
+        FileMover mover = new FileMover(episode);
+        makeConflict(bigBang0322, mover);
+        makeConflict(bigBang0322, mover);
+        makeConflict(bigBang0322, mover);
+        mover.addObserver(new FutureCompleter(future));
+
+        List<FileMover> moveList = new ArrayList<>();
+        moveList.add(mover);
+
+        executeMoveRunnerTest(moveList, future);
+    }
 }

--- a/src/test/java/org/tvrenamer/controller/MoveTest.java
+++ b/src/test/java/org/tvrenamer/controller/MoveTest.java
@@ -13,6 +13,7 @@ import org.junit.rules.TemporaryFolder;
 import org.tvrenamer.model.EpisodeTestData;
 import org.tvrenamer.model.FileEpisode;
 import org.tvrenamer.model.MoveObserver;
+import org.tvrenamer.model.util.Environment;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -180,17 +181,19 @@ public class MoveTest {
         TestUtils.setReadOnly(srcDir);
         assertReady();
 
-        FileMover mover = new FileMover(episode);
-        boolean didMove = mover.call();
+        if (!Environment.IS_WINDOWS) {
+            FileMover mover = new FileMover(episode);
+            boolean didMove = mover.call();
 
-        // Allow the framework to clean up by making the
-        // files writable again.
-        TestUtils.setWritable(srcDir);
-        TestUtils.setWritable(srcFile);
+            // Allow the framework to clean up by making the
+            // files writable again.
+            TestUtils.setWritable(srcDir);
+            TestUtils.setWritable(srcFile);
 
-        assertNotMoved();
-        assertFalse("FileMover.call returned true on read-only file",
-                    didMove);
+            assertNotMoved();
+            assertFalse("FileMover.call returned true on read-only file",
+                        didMove);
+        }
     }
 
     private static class FutureCompleter implements MoveObserver {
@@ -275,11 +278,13 @@ public class MoveTest {
             runner.runThread();
             boolean didMove = future.get(4, TimeUnit.SECONDS);
 
-            // We expect that the file will not be moved, and that the
-            // observer will be called with a negative status.
-            assertNotMoved();
-            assertFalse("expected to get false in finish progress, but got "
-                        + didMove, didMove);
+            if (!Environment.IS_WINDOWS) {
+                // We expect that the file will not be moved, and that the
+                // observer will be called with a negative status.
+                assertNotMoved();
+                assertFalse("expected to get false in finish progress, but got "
+                            + didMove, didMove);
+            }
         } catch (TimeoutException e) {
             String failMsg = "timeout trying to move " + srcFile;
             String exceptionMessage = e.getMessage();

--- a/src/test/java/org/tvrenamer/controller/MoveTest.java
+++ b/src/test/java/org/tvrenamer/controller/MoveTest.java
@@ -83,13 +83,13 @@ public class MoveTest {
     @Rule
     public final TemporaryFolder tempFolder = new TemporaryFolder();
 
-    private Path destDir;
-    private FileEpisode episode;
-    private Path srcFile;
-    private Path srcDir;
-    private Path expectedDest;
+    Path destDir;
+    FileEpisode episode;
+    Path srcFile;
+    Path srcDir;
+    Path expectedDest;
 
-    private void setValues(final EpisodeTestData epdata) {
+    void setValues(final EpisodeTestData epdata) {
         Path tempPath = tempFolder.getRoot().toPath();
         Path sandbox = tempPath.resolve("input");
         destDir = tempPath.resolve("output");
@@ -113,7 +113,7 @@ public class MoveTest {
             .resolve(epdata.expectedReplacement + epdata.filenameSuffix);
     }
 
-    private void assertReady() {
+    void assertReady() {
         assertNotNull("failed to create FileEpisode", episode);
         assertNotNull("FileEpisode does not have path", srcFile);
 
@@ -123,7 +123,7 @@ public class MoveTest {
                    Files.notExists(destDir));
     }
 
-    private void assertMoved() {
+    void assertMoved() {
         assertTrue("did not move " + srcFile + " to expected destination "
                    + expectedDest, Files.exists(expectedDest));
     }
@@ -143,7 +143,7 @@ public class MoveTest {
                    Files.notExists(destDir) || TestUtils.isDirEmpty(destDir));
     }
 
-    private void assertTimestamp(long expected) {
+    void assertTimestamp(long expected) {
         long actualMillis = 0L;
         try {
             FileTime actualTimestamp = Files.getLastModifiedTime(expectedDest);
@@ -196,7 +196,7 @@ public class MoveTest {
         }
     }
 
-    private static class FutureCompleter implements MoveObserver {
+    static class FutureCompleter implements MoveObserver {
         private final CompletableFuture<Boolean> future;
 
         FutureCompleter(final CompletableFuture<Boolean> future) {

--- a/src/test/java/org/tvrenamer/controller/MoveTest.java
+++ b/src/test/java/org/tvrenamer/controller/MoveTest.java
@@ -124,8 +124,10 @@ public class MoveTest {
     }
 
     void assertMoved() {
-        assertTrue("did not move " + srcFile + " to expected destination "
-                   + expectedDest, Files.exists(expectedDest));
+        assertTrue("did not move\n" + srcFile + "\n to expected destination\n"
+                   + expectedDest + "\n (it appears to now be in\n"
+                   + episode.getPath() + ")",
+                   Files.exists(expectedDest));
     }
 
     private void assertNotMoved() {

--- a/src/test/java/org/tvrenamer/controller/MoveTest.java
+++ b/src/test/java/org/tvrenamer/controller/MoveTest.java
@@ -220,19 +220,9 @@ public class MoveTest {
         }
     }
 
-    @Test
-    public void testMoveRunner() {
-        final CompletableFuture<Boolean> future = new CompletableFuture<>();
-
-        setValues(robotChicken0704);
-        assertReady();
-
-        FileMover mover = new FileMover(episode);
-        mover.addObserver(new FutureCompleter(future));
-
-        List<FileMover> moveList = new ArrayList<>();
-        moveList.add(mover);
-
+    void executeMoveRunnerTest(List<FileMover> moveList,
+                               CompletableFuture<Boolean> future)
+    {
         MoveRunner runner = new MoveRunner(moveList);
         try {
             runner.runThread();
@@ -256,6 +246,22 @@ public class MoveTest {
             fail("failure (possibly interrupted?) trying to move "
                  + srcFile + ": " + e.getMessage());
         }
+    }
+
+    @Test
+    public void testMoveRunner() {
+        final CompletableFuture<Boolean> future = new CompletableFuture<>();
+
+        setValues(robotChicken0704);
+        assertReady();
+
+        FileMover mover = new FileMover(episode);
+        mover.addObserver(new FutureCompleter(future));
+
+        List<FileMover> moveList = new ArrayList<>();
+        moveList.add(mover);
+
+        executeMoveRunnerTest(moveList, future);
     }
 
     @Test


### PR DESCRIPTION
Add test that intentionally puts a file in the way of where we would want to move the file, to check how we deal with conflicts.

Improve MoveTest a bit, and other changes deriving from testing things on Windows.

Please see individual commits.