### PR TITLE
Ignore build output from the Tauri experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,8 @@ launch4j.properties
 /src/test/java/org/tvrenamer/controller/TestMain.java
 /commit.log
 /diff.diff
+
+node_modules/
+/src-tauri/target/
+/ui/dist/
+/ui/test-results/


### PR DESCRIPTION
`node_modules/`, `src-tauri/target/`, `ui/dist/` and `ui/test-results/` add up
to nearly 7GB of untracked files, which makes `git status` useless.

Ignores the output paths rather than the `src-tauri/` and `ui/` directories
themselves, so source would still show up if that work resumes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)