### PR TITLE
Ship Windows as a portable zip instead of an installer

### DIFF
--- a/.claude/plans/native-bundles-1.0.md
+++ b/.claude/plans/native-bundles-1.0.md
@@ -26,14 +26,19 @@ master and is not yet pushed.
 | 3. entitlements, CHANGELOG, README | Done. |
 | 4. Certificate and notarisation keys | Done. All six secrets set, none exercised. |
 
-Verification steps 1, 2 and 3 pass, and so does step 5 for aarch64.
+Verification steps 1, 2, 3 and 6 pass, and so does step 5 for aarch64.
 Verification step 4, the `workflow_dispatch`
 run, is now the next thing to do and the first that exercises signing,
 notarisation and the Windows exe. It is blocked on one thing: GitHub only
 offers the Run workflow button for definitions present on the default branch,
 and `workflow_dispatch` lives on this branch, so `release.yml` has to reach
-master before a manual run can start. The x86_64 half of step 5 and all of
-step 6 need artifacts that only CI builds, so both wait on the same merge.
+master before a manual run can start. `workflow_dispatch` turned out to need
+the workflow on the default branch only by name, so a run can be pointed at any
+branch and pick up that branch's copy, which is how the portable zip was tested
+before merging.
+
+What is left: the x86_64 half of step 5, needing an Intel Mac, and step 7, which
+only a real tag exercises.
 
 Every risk except 4 and 7 is closed. Risk 1 was settled by two real notary
 submissions on 22 August 2026, both Accepted with no issues. Risks 4 and 7 are
@@ -374,13 +379,14 @@ Ordered so the cheap checks settle the uncertain things first.
    Afterwards `~/.swt/lib/macosx/aarch64/` held `libswt-cocoa` and
    `libswt-pi-cocoa`. `libswt-awt-cocoa` stays in the jar unless something asks
    for the AWT bridge, so two files rather than three is correct.
-6. **Windows.** Done for the `.exe` installer on 22 August 2026, which then
-   got replaced by the portable zip, so it needs redoing. Extract the zip with
-   Explorer, which propagates the mark of the web, confirm the Zone.Identifier
-   stream is present, then run `TVRenamer\TVRenamer.exe`. Expect the
-   SmartScreen warning, then a working search and rename. Delete the folder and
-   confirm nothing is left behind. No upgrade test any more, since there is no
-   installer to upgrade.
+6. **Windows.** Done twice on 22 August 2026: once for the `.exe` installer,
+   then again for the portable zip that replaced it. The mark of the web
+   survived both extraction steps, `TVRenamer\TVRenamer.exe` ran, and a rename
+   worked. No upgrade test any more, since there is no installer to upgrade.
+
+   An Actions artifact download wraps whatever it contains in a second zip, so
+   testing from a run page means extracting twice. Release assets are not
+   wrapped, so a user extracts once.
 7. **The gate, both directions.** A beta tag must produce 5 zips and no bundles;
    a final tag must produce both. A slip here fails silently by shipping zips
    only, which is the outcome most likely to go unnoticed.

--- a/.claude/plans/native-bundles-1.0.md
+++ b/.claude/plans/native-bundles-1.0.md
@@ -37,8 +37,13 @@ the workflow on the default branch only by name, so a run can be pointed at any
 branch and pick up that branch's copy, which is how the portable zip was tested
 before merging.
 
-What is left: the x86_64 half of step 5, needing an Intel Mac, and step 7, which
-only a real tag exercises.
+What is left: step 7, which only a real tag exercises.
+
+The x86_64 half of step 5 is **skipped for 1.0, deliberately**. No Intel Mac is
+available. CI signed, notarised and stapled that dmg, so the signature and the
+notary ticket are proven; what stays untested is launching the x86_64 SWT
+natives on Intel hardware. Accepted risk, to be picked up from a user report if
+it turns out to be wrong.
 
 Every risk except 4 and 7 is closed. Risk 1 was settled by two real notary
 submissions on 22 August 2026, both Accepted with no issues. Risks 4 and 7 are
@@ -381,8 +386,11 @@ Ordered so the cheap checks settle the uncertain things first.
    for the AWT bridge, so two files rather than three is correct.
 6. **Windows.** Done twice on 22 August 2026: once for the `.exe` installer,
    then again for the portable zip that replaced it. The mark of the web
-   survived both extraction steps, `TVRenamer\TVRenamer.exe` ran, and a rename
-   worked. No upgrade test any more, since there is no installer to upgrade.
+   survived both extraction steps, SmartScreen warned as expected for an
+   unsigned exe, `TVRenamer\TVRenamer.exe` ran, and a rename worked. Whether
+   deleting the folder leaves anything behind was not checked and was judged not
+   worth chasing. No upgrade test any more, since there is no installer to
+   upgrade.
 
    An Actions artifact download wraps whatever it contains in a second zip, so
    testing from a run page means extracting twice. Release assets are not

--- a/.claude/plans/native-bundles-1.0.md
+++ b/.claude/plans/native-bundles-1.0.md
@@ -39,11 +39,12 @@ before merging.
 
 What is left: step 7, which only a real tag exercises.
 
-The x86_64 half of step 5 is **skipped for 1.0, deliberately**. No Intel Mac is
-available. CI signed, notarised and stapled that dmg, so the signature and the
-notary ticket are proven; what stays untested is launching the x86_64 SWT
-natives on Intel hardware. Accepted risk, to be picked up from a user report if
-it turns out to be wrong.
+The x86_64 half of step 5 was covered under Rosetta 2 rather than on Intel
+hardware, which is not available. That still exercises the Intel build itself:
+the x86_64 runtime, the x86_64 SWT natives loading under the hardened runtime,
+Gatekeeper against a Safari download, and a live TVmaze lookup. What remains
+untested is Intel silicon specifically, which for a userspace Java and SWT
+application is a narrow risk. Accepted for 1.0.
 
 Every risk except 4 and 7 is closed. Risk 1 was settled by two real notary
 submissions on 22 August 2026, both Accepted with no issues. Risks 4 and 7 are
@@ -384,6 +385,13 @@ Ordered so the cheap checks settle the uncertain things first.
    Afterwards `~/.swt/lib/macosx/aarch64/` held `libswt-cocoa` and
    `libswt-pi-cocoa`. `libswt-awt-cocoa` stays in the jar unless something asks
    for the AWT bridge, so two files rather than three is correct.
+
+   The x86_64 dmg was then run under Rosetta 2 on the same Apple silicon Mac,
+   downloaded through Safari so it carried quarantine. It assessed as
+   `Notarized Developer ID`, extracted its own natives to
+   `~/.swt/lib/macosx/x86_64/` beside the aarch64 pair, and a TVmaze search
+   returned results. A separate architecture directory is the evidence it ran
+   the Intel binaries rather than falling back to the ARM ones.
 6. **Windows.** Done twice on 22 August 2026: once for the `.exe` installer,
    then again for the portable zip that replaced it. The mark of the web
    survived both extraction steps, SmartScreen warned as expected for an

--- a/.claude/plans/native-bundles-1.0.md
+++ b/.claude/plans/native-bundles-1.0.md
@@ -96,8 +96,8 @@ downloads exactly once, so losing it means revoking and reissuing.
 * Signing and notarisation fail closed on a tag push when the secrets are
   absent, rather than quietly publishing an unsigned dmg that Gatekeeper will
   refuse. A manual run still builds unsigned, so the workflow is testable now.
-* The WiX preflight looks under Program Files and appends what it finds to
-  PATH, rather than only checking PATH.
+* The WiX preflight looked under Program Files and appended what it found to
+  PATH, rather than only checking PATH. Removed with the installer.
 * `.claude/research/jre-less-native-bundles.md` records why bundles carry a
   runtime rather than relying on an installed JRE. Briefly: jpackage cannot
   build a runtime-less image at all, and a Temurin JRE download is larger than
@@ -148,7 +148,12 @@ measurable.
    containing `b` ships zips only. No version mapping.
 2. The zip keeps shipping on every platform alongside any bundle.
 3. macOS `.dmg` signed with a Developer ID Application certificate, and notarized.
-4. Windows `.exe` unsigned for now.
+4. Windows ships a portable zip, not an installer, and nothing on Windows is
+   signed. Chosen after building the exe and testing it: an installer buys a
+   Start menu entry and an uninstaller, and costs the WiX dependency, an
+   upgrade UUID and an upgrade test. Unzip and run needs no admin rights and
+   writes nothing to the registry. SmartScreen warns either way, since the
+   warning follows the missing signature, not the packaging.
 5. Linux stays zip-only.
 
 ## Settled by inspecting a bundle built during planning
@@ -226,9 +231,11 @@ when a `macSignIdentity` property or env var is present, `--mac-sign`,
 `--mac-signing-key-user-name` and `--mac-entitlements`. Absent it, the build is
 unsigned, so local builds need no Apple setup and take the same code path.
 
-Windows adds `--type exe`, `--win-shortcut`, `--win-menu`, `--win-dir-chooser`
-and a fixed `--win-upgrade-uuid`, generated once and never changed, so upgrades
-replace the install instead of landing side by side.
+Windows uses `--type app-image`, which leaves a directory rather than a file,
+so there is nothing to rename. A `portableZip` task packs it as
+`TVRenamer-<version>-<platform>-portable.zip`, nested under one folder so
+extracting does not spray a runtime across the user's downloads. No WiX, no
+installer options, no upgrade UUID.
 
 Validate the version shape with a regex before invoking jpackage and fail with a
 clear message. The `b` gate treats `1.0rc1` as final, and it should not reach
@@ -251,8 +258,8 @@ the prerelease flag cannot disagree.
 
 In the existing matrix, gated on `is_final == 'true'`: on macOS import the
 certificate, run `jpackageBundle`, then notarize and staple. On Windows just run
-`jpackageBundle`, with a preflight that WiX is on `PATH` so a future runner image
-change gives a one-line error rather than a cryptic jpackage failure.
+`jpackageBundle`. No WiX preflight, since `--type app-image` does not shell out
+to WiX at all.
 
 Keychain import, into a temporary keychain so exactly one identity is present and
 nothing can trigger an unanswerable GUI prompt:
@@ -289,8 +296,9 @@ Both Mac runners produce a dmg, so that is two signings and two notarizations pe
 release. Notarization is minutes each, roughly tripling release time.
 
 **Fail closed on artifact counts** in `publish`, before creating the release:
-assert 5 zips always, plus 2 dmgs and 1 exe when `is_final`, and 0 of each when
-not. This is the real defence against the gate silently skipping, since a
+assert 5 plain zips always, plus 2 dmgs and 1 portable zip when `is_final`, and
+0 of each when not. The portable zip matches `dist/*.zip` too, so subtract it
+from the plain count or one Windows download stands in for a missing platform. This is the real defence against the gate silently skipping, since a
 mistyped job output evaluates to empty and therefore falsey. It also catches
 bundles leaking into a beta.
 
@@ -366,9 +374,13 @@ Ordered so the cheap checks settle the uncertain things first.
    Afterwards `~/.swt/lib/macosx/aarch64/` held `libswt-cocoa` and
    `libswt-pi-cocoa`. `libswt-awt-cocoa` stays in the jar unless something asks
    for the AWT bridge, so two files rather than three is correct.
-6. **Windows.** Install the `.exe`, expect a SmartScreen warning, launch from the
-   Start menu, rename a file, uninstall. Then reinstall a bumped version to
-   confirm `--win-upgrade-uuid` upgrades rather than installing side by side.
+6. **Windows.** Done for the `.exe` installer on 22 August 2026, which then
+   got replaced by the portable zip, so it needs redoing. Extract the zip with
+   Explorer, which propagates the mark of the web, confirm the Zone.Identifier
+   stream is present, then run `TVRenamer\TVRenamer.exe`. Expect the
+   SmartScreen warning, then a working search and rename. Delete the folder and
+   confirm nothing is left behind. No upgrade test any more, since there is no
+   installer to upgrade.
 7. **The gate, both directions.** A beta tag must produce 5 zips and no bundles;
    a final tag must produce both. A slip here fails silently by shipping zips
    only, which is the outcome most likely to go unnoticed.
@@ -393,11 +405,19 @@ Ordered so the cheap checks settle the uncertain things first.
    notarization. Verified absent in a local JBR build; check on CI.
 6. **`1.0rc1`-shaped versions** pass the `b` gate. Regex-validate in Gradle.
 7. **`notarytool` exiting 0 with status `Invalid`.** Parse the status.
-8. **WiX missing from `PATH`** on a future `windows-latest` image.
+8. ~~**WiX missing from `PATH`** on a future `windows-latest` image.~~ Gone
+   with the installer. The `cygpath` fix for it was never exercised, because
+   every run so far found WiX already on `PATH`.
 
 ## Not in scope
 
-* Windows code signing. Needs a purchased certificate.
+* Windows code signing. Needs a purchased certificate. Checked after building:
+  Azure Artifact Signing is the cheap route, but public trust certificates for
+  individual developers are limited to the United States and Canada, and the
+  organization track New Zealand qualifies for needs a registered legal entity.
+  A conventional OV certificate must also live on FIPS 140-2 hardware now, and
+  does not clear SmartScreen until reputation accrues. The warning stays for
+  1.0.
 * Linux `.deb` and `.rpm`.
 * The `ICON_PARENT_DIRECTORY` fallback and the dead `etc/default-overrides.xml`
   seed.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,26 +127,6 @@ jobs:
           path: build/distributions/*.zip
           if-no-files-found: error
 
-      # jpackage shells out to WiX and fails obscurely without it. Newer runner
-      # images have moved it more than once, so look for it and say so plainly.
-      - name: Find WiX
-        if: env.BUNDLE == 'true' && runner.os == 'Windows'
-        shell: bash
-        run: |
-          set -eu
-          if command -v candle.exe >/dev/null; then
-            exit 0
-          fi
-          found=$(find '/c/Program Files (x86)' -maxdepth 3 -name candle.exe 2>/dev/null | head -1)
-          if [ -z "$found" ]; then
-            echo "WiX is not installed on this runner image, so jpackage cannot build an exe"
-            exit 1
-          fi
-          # A native path, not the MSYS one find returns. GITHUB_PATH is
-          # prepended to PATH verbatim, and candle.exe is launched by jpackage,
-          # which cannot resolve '/c/Program Files (x86)/...'.
-          cygpath -w "$(dirname "$found")" >> "$GITHUB_PATH"
-
       # A temporary keychain, so the certificate never touches the login
       # keychain and nothing can raise a prompt that no one is there to answer.
       # It is prepended to the search list rather than replacing it, so
@@ -287,7 +267,7 @@ jobs:
           name: bundle-${{ matrix.label }}
           path: |
             build/jpackage/*.dmg
-            build/jpackage/*.exe
+            build/jpackage/*-portable.zip
           if-no-files-found: error
 
   release:
@@ -326,16 +306,20 @@ jobs:
         run: |
           set -eu
           shopt -s nullglob
-          zips=(dist/*.zip)
+          # The portable zip also matches dist/*.zip, so take it out of the
+          # plain count rather than letting one Windows download stand in for a
+          # missing platform.
+          all_zips=(dist/*.zip)
+          portable=(dist/*-portable.zip)
           dmgs=(dist/*.dmg)
-          exes=(dist/*.exe)
+          plain=$(( ${#all_zips[@]} - ${#portable[@]} ))
 
           if [ "${{ needs.meta.outputs.is_final }}" = true ]; then
             want_dmgs=2
-            want_exes=1
+            want_portable=1
           else
             want_dmgs=0
-            want_exes=0
+            want_portable=0
           fi
 
           fail=0
@@ -345,11 +329,11 @@ jobs:
               fail=1
             fi
           }
-          check zips "${#zips[@]}" 5
+          check zips "$plain" 5
           check dmgs "${#dmgs[@]}" "$want_dmgs"
-          check exes "${#exes[@]}" "$want_exes"
+          check "portable zips" "${#portable[@]}" "$want_portable"
 
-          printf '%s\n' "${zips[@]}" "${dmgs[@]}" "${exes[@]}"
+          printf '%s\n' "${all_zips[@]}" "${dmgs[@]}"
           exit $fail
 
       - name: Assemble release notes
@@ -391,7 +375,7 @@ jobs:
           # An unmatched glob is passed through literally, and gh then errors on
           # a file called 'dist/*.dmg'. An array built with nullglob cannot.
           shopt -s nullglob
-          assets=(dist/*.zip dist/*.dmg dist/*.exe)
+          assets=(dist/*.zip dist/*.dmg)
 
           gh release create "$GITHUB_REF_NAME" \
             --verify-tag \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,18 +3,23 @@
 ## 1.0
 
 Double-click installation is back on macOS and Windows. The `.dmg` and the
-`.exe` carry their own Java runtime, so there is nothing to install first.
+Windows portable zip carry their own Java runtime, so there is nothing to
+install first.
 
 ### You need to know
 
 * **The bundles include Java.** That is why they are around 50MB against the
   zip's 7MB. You do not need your own Java to run them.
-* **The zip still ships for every platform.** If you already have Java 21 it is
-  the smaller download, and nothing about it has changed.
+* **Windows has no installer.** Unzip `windows-x86_64-portable.zip` anywhere
+  and run `TVRenamer\TVRenamer.exe`. No admin rights, nothing written to the
+  registry, and you uninstall it by deleting the folder. Do not confuse it with
+  `windows-x86_64.zip`, which is the small one that needs your own Java.
+* **The plain zip still ships for every platform.** If you already have Java 21
+  it is the smaller download, and nothing about it has changed.
 * **The macOS bundle is signed and notarised**, so it opens without the warning
   the zip gives.
-* **Windows will warn you.** The `.exe` is not signed yet, so SmartScreen shows
-  a warning. Choose 'More info', then 'Run anyway'.
+* **Windows will warn you.** Nothing is signed on Windows yet, so SmartScreen
+  shows a warning the first time. Choose 'More info', then 'Run anyway'.
 * **Linux stays zip-only.**
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It will take an ugly filename like **Lost.[6x05].DD51.720p.WEB-DL.AVC-FUSiON.mkv
 >
 > Again, we assure you the program contains no viruses.
 
-[Download](https://github.com/tvrenamer/tvrenamer/releases) the installer for
+[Download](https://github.com/tvrenamer/tvrenamer/releases) the bundle for
 your operating system and processor. It carries its own Java runtime, so there
 is nothing to install first:
 
@@ -33,16 +33,20 @@ is nothing to install first:
 | --- | --- |
 | `macos-aarch64.dmg` | Macs with Apple silicon (M1 and later) |
 | `macos-x86_64.dmg` | Intel Macs |
-| `windows-x86_64.exe` | Windows on Intel or AMD |
+| `windows-x86_64-portable.zip` | Windows on Intel or AMD |
 
-On macOS, open the `.dmg` and drag TVRenamer to your Applications folder. On
-Windows, run the `.exe`. It is not signed yet, so SmartScreen will warn you:
-choose 'More info', then 'Run anyway'.
+On macOS, open the `.dmg` and drag TVRenamer to your Applications folder.
+
+On Windows, unzip it anywhere and run `TVRenamer\TVRenamer.exe` from inside.
+There is no installer, so it needs no admin rights and you remove it by
+deleting the folder. It is not signed yet, so SmartScreen will warn you the
+first time: choose 'More info', then 'Run anyway'.
 
 ### The zip
 
-Every platform also has a zip. It is much smaller, around 7MB against 50MB,
-because it has no Java in it. Linux has only this. Install
+Every platform also has a plain zip. It is much smaller, around 7MB against
+50MB, because it has no Java in it. Linux has only this. Note the Windows one
+is `windows-x86_64.zip`, not the `-portable` zip above. Install
 [Java 21 or later](https://adoptium.net/), then download the zip matching your
 operating system and processor:
 

--- a/build.gradle
+++ b/build.gradle
@@ -132,10 +132,6 @@ def runtimeModules = ['java.base',
                       'jdk.localedata',
                       'jdk.charsets']
 
-// Generated once. Changing it makes Windows install the new version alongside
-// the old one instead of upgrading it.
-def winUpgradeUuid = 'f4b7f32a-b131-482e-bec6-ef0f1e30881e'
-
 def jdkHome = System.getProperty('java.home')
 def runtimeImageDir = layout.buildDirectory.dir('jpackage-runtime')
 def bundleDir = layout.buildDirectory.dir('jpackage')
@@ -162,12 +158,15 @@ tasks.register('trimmedRuntime', Exec) {
 
 tasks.register('jpackageBundle', Exec) {
     group = 'distribution'
-    description = 'Builds a double-clickable installer carrying a trimmed Java runtime.'
+    description = 'Builds a double-clickable bundle carrying a trimmed Java runtime.'
 
     dependsOn 'installDist', 'trimmedRuntime'
     onlyIf { isMacOs || isWindows }
 
-    def bundleType = isMacOs ? 'dmg' : 'exe'
+    // Windows gets an app image rather than an installer. Extracting a zip
+    // and running TVRenamer.exe needs no admin rights, writes nothing to the
+    // registry, and drops the WiX dependency the exe build needed.
+    def bundleType = isMacOs ? 'dmg' : 'app-image'
     def iconFile = file(isMacOs ? 'src/main/resources/icons/tvrenamer.icns'
                                 : 'src/main/resources/icons/oldschool-tv-icon.ico')
     def signIdentity = findProperty('macSignIdentity') ?: System.getenv('MAC_SIGN_IDENTITY')
@@ -211,15 +210,22 @@ tasks.register('jpackageBundle', Exec) {
                             '--mac-signing-key-user-name', signIdentity,
                             '--mac-entitlements', file('etc/entitlements.plist').absolutePath]
             }
-        } else {
-            command += ['--win-shortcut', '--win-menu', '--win-dir-chooser',
-                        '--win-upgrade-uuid', winUpgradeUuid]
         }
 
         commandLine command
     }
 
     doLast {
+        if (!isMacOs) {
+            // An app image is a directory named from --name, which portableZip
+            // packs. Nothing to rename, so just check jpackage produced it.
+            def launcher = bundleDir.get().file('TVRenamer/TVRenamer.exe').asFile
+            if (!launcher.exists()) {
+                throw new GradleException("jpackage reported success but ${launcher} is missing.")
+            }
+            return
+        }
+
         def built = bundleDir.get().file("TVRenamer-${project.version}.${bundleType}").asFile
         if (!built.exists()) {
             throw new GradleException("jpackage reported success but ${built} is missing.")
@@ -274,6 +280,26 @@ tasks.register('signDmg', Exec) {
     }
 }
 
-// Attached as a finaliser rather than a separate call, so `gradlew
+// The Windows half of the bundle. jpackage leaves an app image directory
+// behind; this is what a user actually downloads. Named apart from the plain
+// distZip, which carries no runtime and needs Java 21 already installed.
+tasks.register('portableZip', Zip) {
+    group = 'distribution'
+    description = 'Packs the Windows app image into a zip that runs without installing.'
+
+    // Same reasoning as signDmg: a finaliser runs even when the task it
+    // finalises fails, and a Zip task over a missing directory would write an
+    // empty archive rather than failing.
+    onlyIf { isWindows && bundleDir.get().dir('TVRenamer').asFile.exists() }
+
+    from bundleDir.map { it.dir('TVRenamer') }
+    // Nested so extracting gives one folder rather than spraying the runtime
+    // across wherever the user unzipped it.
+    into 'TVRenamer'
+    destinationDirectory = bundleDir
+    archiveFileName = "TVRenamer-${project.version}-${platformLabel}-portable.zip"
+}
+
+// Attached as finalisers rather than separate calls, so `gradlew
 // jpackageBundle` in the release workflow keeps working unchanged.
-tasks.named('jpackageBundle') { finalizedBy 'signDmg' }
+tasks.named('jpackageBundle') { finalizedBy 'signDmg', 'portableZip' }


### PR DESCRIPTION
Windows now gets `TVRenamer-<version>-windows-x86_64-portable.zip` built with
`jpackage --type app-image`, instead of an `.exe` installer. Unzip anywhere and
run `TVRenamer\TVRenamer.exe`. No admin rights, nothing in the registry, and
uninstalling is deleting the folder.

That suits a utility people try once, and it removes the most fragile part of
the Windows pipeline: the WiX dependency and its PATH preflight, the upgrade
UUID, and the upgrade half of the verification plan.

SmartScreen still warns. That follows the missing signature rather than the
packaging, so it is unchanged either way. Signing stays out of scope: Azure
Artifact Signing restricts individual developers to the US and Canada, and the
organization track New Zealand qualifies for needs a registered legal entity.
An OV certificate would also have to live on FIPS 140-2 hardware and would not
clear the warning until reputation accrues.

Windows now has two zips, so they are named clearly apart. The small
`windows-x86_64.zip` needs Java 21 installed. The `-portable` one carries its
own runtime at around 50MB. The artifact count check in `publish` subtracts the
portable zip from the plain count, so a Windows download cannot stand in for a
missing platform.

Verified so far only on macOS, where the dmg path is unchanged and `portableZip`
correctly skips. The Windows side needs a `workflow_dispatch` run against this
branch and then a manual test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017uhEtYdBquVJey1s8tsFrE