### PR TITLE
Update screenshot and fix the rename example

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [![Build Status](https://github.com/tvrenamer/tvrenamer/actions/workflows/build.yml/badge.svg)](https://github.com/tvrenamer/tvrenamer/actions/workflows/build.yml)
 ## About
 TVRenamer is a Java GUI utility to rename TV episodes from TV listings
-It will take an ugly filename like **Lost.[6x05].DD51.720p.WEB-DL.AVC-FUSiON.mkv** and rename it to **Lost S06E05 Lighthouse.mkv**
+It will take an ugly filename like **Lost.S06E05.Lighthouse.DD51.720p.WEB-DL.AVC-FUSiON.mkv** and rename it to **Lost [6x05] Lighthouse.mkv**
 
 ## [Screenshot](https://github.com/tvrenamer/tvrenamer/wiki/Screenshots)
-![Screenshot](https://raw.githubusercontent.com/wiki/tvrenamer/tvrenamer/tvrenamer-0.5b2.png)
+![Screenshot](https://raw.githubusercontent.com/wiki/tvrenamer/tvrenamer/tvrenamer-1.0.png)
 
 ## Features
  * Rename many different shows at once from information from [TVmaze](https://www.tvmaze.com/)


### PR DESCRIPTION
Closes #431.

The new screenshot is in the wiki as `tvrenamer-1.0.png`, replacing the 0.5b2 one on the [Screenshots](https://github.com/tvrenamer/tvrenamer/wiki/Screenshots) page. The README links to it the same way it linked to the old one, so no image is committed here.

Also fixes the About example. It had the input and output swapped, and the output format it claimed is not what the default mask `%S [%sx%0e] %t` produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)